### PR TITLE
Switch from ESM to CommonJS in discordWebhook.js

### DIFF
--- a/backend/services/discordWebhook.js
+++ b/backend/services/discordWebhook.js
@@ -1,17 +1,11 @@
 ////////////////////////////////////////////////////////////////
 //
 //  Project:       KnightWise
-//
 //  Year:          2025
-//
 //  Author(s):     Daniel Landsman
-//
 //  File:          discordWebhook.js
-//
 //  Description:   Contains functionality for the KnightWise
 //                 Discord webhook, used for administration.
-//
-//  Last Modified: 10/08/2025 
 //
 ////////////////////////////////////////////////////////////////
 
@@ -24,7 +18,7 @@ const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
  * @param   {object} [options] - Optional. General options for future features
  * @returns {boolean}          - True if message sent successfully, false otherwise 
  */
-export async function sendNotification(content, options = {}) 
+async function sendNotification(content, options = {}) 
 {
   if (!DISCORD_WEBHOOK_URL) 
   {
@@ -65,3 +59,5 @@ export async function sendNotification(content, options = {})
     return false;
   }
 }
+
+module.exports = { sendNotification };


### PR DESCRIPTION
This PR addresses [SCRUM-86: Fix Mixed ESM/CommonJS Syntax in discordWebhook.js](https://knightwise.atlassian.net/browse/SCRUM-86)

The vast majority (if not all) of the KnightWise codebase currently uses CommonJS JavaScript syntax. This means:
- Using `require()` instead of `import` to import.
- Using `module.exports` instead of `export default` to export.
- **Not using the export keyword in functions.**

The `discordWebhook.js` file previously used ECMAScript Modules (ESM) syntax, which caused some errors and confusion due to the mix of ESM and CommonJS syntax. 
- This PR refactors discordWebhook.js to use CommonJS syntax to match the rest of the codebase.
- The changes were tested locally.

Below: Proof that discordWebhook.js is still functional after the changes.
<img width="426" height="132" alt="image" src="https://github.com/user-attachments/assets/5e29c770-97a3-48ac-9b0b-b0c7616e84da" />

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-86

