### PR TITLE
HOTFIX: Disable frontend tests in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -33,9 +33,14 @@ jobs:
         working-directory: ./backend
         run: npm test
         env:
-          MONGO_URI: mongodb://localhost:27017/test-studytool
-          JWT_SECRET: test_jwt_secret
-          NODE_ENV: test
+          DB_HOST: ${{ secrets.DB_HOST_TEST }}
+          DB_USER: ${{ secrets.DB_USER_TEST }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD_TEST }}
+          DB_NAME: ${{ secrets.DB_NAME_TEST }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET_TEST }}
+          MJ_APIKEY_PUBLIC: ${{ secrets.MJ_APIKEY_PUBLIC_TEST }}
+          MJ_APIKEY_PRIVATE: ${{ secrets.MJ_APIKEY_PRIVATE_TEST }}
+          RAPIDAPI_KEY: ${{ secrets.RAPIDAPI_KEY_TEST }}
 
   test-frontend:
     name: test frontend

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,9 +60,9 @@ jobs:
         working-directory: ./frontend
         run: npm run lint
 
-      - name: run frontend tests
-        working-directory: ./frontend
-        run: npm test
+#      - name: run frontend tests
+ #       working-directory: ./frontend
+ #       run: npm test
 
       - name: build frontend
         working-directory: ./frontend


### PR DESCRIPTION
- This PR does not address a specific Jira task, it is just a fix for the CI/CD pipeline.
- This PR temporarily disables frontend tests until frontend tests are added to the KnightWise codebase.
- This PR also adds the new test environment variables needed to run backend tests.
  - This involved creating new GitHub secret variables for this repo.