### PR TITLE
SCRUM-122: Enforce Unique Password on Password Reset

### DIFF
--- a/frontend/src/components/ResetPassword.tsx
+++ b/frontend/src/components/ResetPassword.tsx
@@ -10,6 +10,7 @@
 //                 react-password-checklist
 //                 react-router-dom
 //                 api instance
+//                 axios (isAxiosError)
 //
 ////////////////////////////////////////////////////////////////
 
@@ -18,6 +19,7 @@ import PasswordChecklist from "react-password-checklist";
 import { useNavigate } from "react-router-dom";
 import logo from "../assets/ucflogo.png";
 import api from "../api";
+import { isAxiosError } from "axios";
 
 const ResetPassword: React.FC = () => {
   const [password, setPassword] = useState("");
@@ -50,9 +52,16 @@ const ResetPassword: React.FC = () => {
       localStorage.removeItem("reset_email");
       setTimeout(() => navigate("/"), 1000);
     } 
-    catch 
+    catch (err : unknown) 
     {
-      setError("Failed to reset password. Please try again.");
+      if (isAxiosError(err))
+      {
+        setError(err.response?.data?.message || "Failed to reset password. Please try again.");
+      }
+      else
+      {
+        setError("Something went wrong. Please try again.");
+      }
     }
   };
 

--- a/frontend/src/components/ResetPassword.tsx
+++ b/frontend/src/components/ResetPassword.tsx
@@ -48,9 +48,12 @@ const ResetPassword: React.FC = () => {
     try 
     {
       await api.post("/api/auth/resetPassword", { email, password });
-      setSuccessMessage("Password changed successfully!");
+      setSuccessMessage("Password changed successfully! Redirecting...");
+
+      await new Promise(resolve => setTimeout(resolve, 3000));
+
+      navigate("/");
       localStorage.removeItem("reset_email");
-      setTimeout(() => navigate("/"), 1000);
     } 
     catch (err : unknown) 
     {


### PR DESCRIPTION
- This PR addresses [SCRUM-122: Prevent Users Resetting Password with Same Password](https://knightwise.atlassian.net/browse/SCRUM-122).
- This PR updates the backend `/resetPassword` endpoint to ensure users can only reset their password if their new password is different than their current one.
- This PR updates the frontend ResetPassword component to present an error message if a user tries to reset their password with their current one.
  - Also fixed a timing bug where, upon successful password reset, the user would be redirected too quickly to see the success message.
- This PR adds a test to the authentication tests to verify this functionality.
- The changes were tested locally.

Below: The new frontend error message.
<img width="838" height="935" alt="image" src="https://github.com/user-attachments/assets/0a630358-46da-4a70-bc51-f222ae889e24" />

Below: The test report showing the new test passing.
<img width="1141" height="681" alt="test" src="https://github.com/user-attachments/assets/4cd7bc4e-da2c-409b-ba95-a6b2edbbaddf" />

Below: We can finally see the success message!
<img width="896" height="928" alt="success" src="https://github.com/user-attachments/assets/3274f090-561f-4bcd-a4b0-1ae730bf5652" />


Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-122