### PR TITLE
SCRUM-130: Add Progress Support for Mock Test Submissions

### DIFF
--- a/frontend/src/components/MockTestProblem.tsx
+++ b/frontend/src/components/MockTestProblem.tsx
@@ -28,6 +28,7 @@ type Props = {
   handleNext: () => void; // click next
   showFeedback: boolean; // check if the last question or not
   isCorrect: boolean; // check correct answer
+  isSubmitting: boolean; // currently processing submit
 };
 
 const MockTestProblem: React.FC<Props> = ({
@@ -40,6 +41,7 @@ const MockTestProblem: React.FC<Props> = ({
   handleNext,
   showFeedback,
   isCorrect,
+  isSubmitting,
 }) => (
   <div className="max-w-3xl mx-auto px-4 sm:px-6 md:px-8 mt-12 sm:mt-16 md:mt-20">
     {/* top: section, category, subcategory, exam date */}
@@ -96,11 +98,12 @@ const MockTestProblem: React.FC<Props> = ({
     <div className="mt-6">
       <button
         onClick={showFeedback ? handleNext : handleSubmit}
+        disabled={isSubmitting}
         className={`px-5 sm:px-6 py-2 sm:py-3 rounded shadow font-semibold text-sm sm:text-base md:text-lg ${
           showFeedback
             ? "bg-yellow-400 hover:bg-yellow-500 text-black"
             : "bg-yellow-600 hover:bg-yellow-700 text-white"
-        }`}
+        } disabled:opacity-60 disabled:cursor-not-allowed`}
       >
         {showFeedback
           ? currentIndex + 1 === total


### PR DESCRIPTION
- This PR addresses [SCRUM-130: Mock Test Submissions Not Logged to My Progress Tab](https://knightwise.atlassian.net/browse/SCRUM-130).
- This PR implements frontend changes to ensure responses submitted in the Mock Test tab are properly logged to the My Progress tab.
  - Added a call to the `/submit` endpoint in the MockTestPage component.
  - Added submit button disabling/enabling in the MockTestProblem component.
    - Adding a submit call to the backend creates a slight wait time, and users could abuse this by spamming the submit button before the submission is complete, resulting in multiple database queries and multiple API calls. This is bad.
    - The new changes disable the button until the submission is complete, preventing button spamming.
- The changes were tested locally.

Below: Submitting a response to a Mock Test problem now calls the `/submit` endpoint.
<img width="1919" height="920" alt="sendsubmit" src="https://github.com/user-attachments/assets/070acb67-d2f6-4b5e-b78b-c75f57ac9d45" />

Below: The previous submission now logs to the My Progress page properly.
<img width="1919" height="944" alt="updatedprogress" src="https://github.com/user-attachments/assets/c9e0a497-4440-4890-9fe9-338b2c24d048" />

Below: Disabled and enabled buttons (the mouse also turns into the disabled icon when hovering over it, but this doesn't show in the screenshot).
<img width="701" height="310" alt="disabled" src="https://github.com/user-attachments/assets/1a08e55c-6d2a-406d-97b9-a26474f42525" />
<img width="595" height="240" alt="enabled" src="https://github.com/user-attachments/assets/9ddf09ca-7520-420a-b157-31f8a02e36da" />

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-130