### PR TITLE
SCRUM-119: Admin API Endpoints

### DIFF
--- a/backend/__test__/admin.test.js
+++ b/backend/__test__/admin.test.js
@@ -52,13 +52,13 @@ describe("Admin Routes", () => {
       const res = await request(app)
         .get("/api/admin/getuser")
         .set("Authorization", `Bearer ${token}`)
-        .send({id: userId});
+        .query({id: userId});
       
       expect(res.statusCode).toBe(200);
     });
 
     test("GET /api/admin/getuser gets a user with a username", async () => {
-      const [result] = await pool.query(
+      await pool.query(
         'INSERT INTO User (USERNAME, EMAIL, PASSWORD, FIRSTNAME, LASTNAME) VALUES (?, ?, ?, ?, ?)',
         ["anothertest", "testttest@email.com", TEST_USER.password, TEST_USER.firstName, TEST_USER.lastName]
       );
@@ -66,7 +66,7 @@ describe("Admin Routes", () => {
       const res = await request(app)
         .get("/api/admin/getuser")
         .set("Authorization", `Bearer ${token}`)
-        .send({username: "anothertest"});
+        .query({username: "anothertest"});
 
       expect(res.statusCode).toBe(200);
     });

--- a/backend/__test__/admin.test.js
+++ b/backend/__test__/admin.test.js
@@ -1,0 +1,235 @@
+const request = require("supertest");
+const bcrypt = require("bcryptjs");
+const { app, pool } = require("../server");
+const { TEST_USER, verifyTestDatabase } = require("./testHelpers");
+
+// Mock Discord webhook
+jest.mock('../services/discordWebhook', () => ({
+  sendNotification: jest.fn().mockResolvedValue(true),
+  notifyUserEvent: jest.fn().mockResolvedValue(true),
+  notifyError: jest.fn().mockResolvedValue(true),
+}));
+
+const headers = {
+  'Authorization': `Bearer ${process.env.ADMIN_KEY}`,
+  'Content-Type': "application/json",
+}
+
+let token = process.env.ADMIN_KEY;
+
+// Test setup/teardown
+// Clear test tables before/after each test
+beforeAll(async () => {
+  // Extra database safety check
+  await verifyTestDatabase(pool);
+
+  await pool.query("DELETE FROM User");
+  await pool.query("DELETE FROM Professor");
+  await pool.query("DELETE FROM EmailCode");
+  await pool.query('DELETE FROM AnswerText');
+  await pool.query('DELETE FROM Question');
+});
+
+afterEach(async () => {
+  await pool.query('DELETE FROM Response');
+  await pool.query("DELETE FROM Professor");
+  await pool.query('DELETE FROM AnswerText');
+  await pool.query('DELETE FROM Question');
+  await pool.query("DELETE FROM User");
+});
+
+describe("Admin Routes", () => {
+
+    // user endpoints
+    test("GET /api/admin/getuser gets a user with an id", async () => {
+      const [result] = await pool.query(
+        'INSERT INTO User (USERNAME, EMAIL, PASSWORD, FIRSTNAME, LASTNAME) VALUES (?, ?, ?, ?, ?)',
+        ["testingforever", "testtest@email.com", TEST_USER.password, TEST_USER.firstName, TEST_USER.lastName]
+      );
+
+      const userId = result.insertId;
+
+      const res = await request(app)
+        .get("/api/admin/getuser")
+        .set("Authorization", `Bearer ${token}`)
+        .send({id: userId});
+      
+      expect(res.statusCode).toBe(200);
+    });
+
+    test("GET /api/admin/getuser gets a user with a username", async () => {
+      const [result] = await pool.query(
+        'INSERT INTO User (USERNAME, EMAIL, PASSWORD, FIRSTNAME, LASTNAME) VALUES (?, ?, ?, ?, ?)',
+        ["anothertest", "testttest@email.com", TEST_USER.password, TEST_USER.firstName, TEST_USER.lastName]
+      );
+
+      const res = await request(app)
+        .get("/api/admin/getuser")
+        .set("Authorization", `Bearer ${token}`)
+        .send({username: "anothertest"});
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    test("POST /api/admin/createuser creates a new user", async () => {
+
+      const res = await request(app)
+        .post("/api/admin/createuser")
+        .set("Authorization", `Bearer ${token}`)
+        .send({
+          username: "testerstesttest",
+          email: "supertest@test.com",
+          password: TEST_USER.password,
+          firstName: TEST_USER.firstName,
+          lastName: TEST_USER.lastName
+        });
+      
+      expect(res.statusCode).toBe(201);
+      expect(res.body.message).toBe("User Registered");
+    });
+
+    test("DELETE /api/admin/users/:id deletes a user", async () => {
+      const [result] = await pool.query(
+        'INSERT INTO User (USERNAME, EMAIL, PASSWORD, FIRSTNAME, LASTNAME) VALUES (?, ?, ?, ?, ?)',
+        ["testingtestguytest", "test@email.com", TEST_USER.password, TEST_USER.firstName, TEST_USER.lastName]
+      );
+
+      const userId = result.insertId;
+
+      const res = await request(app)
+        .del(`/api/admin/users/${userId}`)
+        .set(headers);
+      
+      expect(res.body.message).toBe("Account deleted successfully");
+      expect(res.statusCode).toBe(200);
+    });
+
+    // question tests
+    test("GET /api/admin/problems/:id retieves a question", async () => {
+      const [result] = await pool.query(
+        'INSERT INTO Question (QUESTION_TEXT, SUBCATEGORY, SECTION) VALUES (?, ?, ?)',
+        ["Q1", "test", "A"]
+      );
+
+      const questionId = result.insertId
+      
+      const res = await request(app)
+        .get(`/api/admin/problems/${questionId}`)
+        .set(headers);
+      
+      expect(res.statusCode).toBe(200);
+    });
+
+    test("POST /api/admin/createquestion creates a question", async () => {
+      const question = {
+        type: 'type',
+        author_exam_id: 'author',
+        section: 'sec',
+        category: 'cat',
+        subcategory: 'sub',
+        points_possible: 1.0,
+        question_text: 'alias',
+        owner_id: null,
+        answer_text: ['a'],
+        answer_correctness: [1],
+        answer_priority: [1],
+      }
+
+      const res = await request(app)
+        .post('/api/admin/createquestion')
+        .set('Authorization', `Bearer ${process.env.ADMIN_KEY}`)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .send(question);
+      
+      expect(res.body.message).toBe("Question added");
+      expect(res.statusCode).toBe(201);
+    });
+
+    test("DELETE /api/admin/problems/:id deletes a question", async () => {
+      const [result] = await pool.query(
+        'INSERT INTO Question (QUESTION_TEXT, SUBCATEGORY, SECTION) VALUES (?, ?, ?)',
+        ["Q1", "test", "A"]
+      );
+
+      const questionId = result.insertId
+
+      const res = await request(app)
+        .del(`/api/admin/problems/${questionId}`)
+        .set(headers);
+      
+      expect(res.body.message).toBe("Question deleted successfully");
+      expect(res.statusCode).toBe(200);
+    });
+
+    // verification tests
+    test("GET /api/admin/unverifiedprofs returns unverified profs", async () => {
+      const [result] = await pool.query(
+        'INSERT INTO Professor (USERNAME, EMAIL, PASSWORD, FIRSTNAME, LASTNAME, VERIFIED) VALUES (?, ?, ?, ?, ?, ?)',
+        [TEST_USER.username, "test@email.com", TEST_USER.password, TEST_USER.firstName, TEST_USER.lastName, 0]
+      );
+
+      const res = await request(app)
+        .get("/api/admin/unverifiedprofs")
+        .set(headers);
+      expect(res.statusCode).toBe(200);
+    });
+
+    test("POST /api/admin/verifyprof/:id verifies a prof", async () => {
+      const [result] = await pool.query(
+        'INSERT INTO Professor (USERNAME, EMAIL, PASSWORD, FIRSTNAME, LASTNAME, VERIFIED) VALUES (?, ?, ?, ?, ?, ?)',
+        [TEST_USER.username, "test@email.com", TEST_USER.password, TEST_USER.firstName, TEST_USER.lastName, 0]
+      );
+
+      const profId = result.insertId
+      const res = await request(app)
+        .post(`/api/admin/verifyprof/${profId}`)
+        .set(headers);
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    
+
+    // admin tokens tests
+    test("DELETE /api/admin/users/:id requires admin token", async () => {
+      const res = await request(app).delete("/api/admin/users/noauth");
+      expect(res.statusCode).toBe(401);
+    });
+
+    test("POST /api/admin/createuser requires admin token", async () => {
+      const res = await request(app).post("/api/admin/createuser");
+      expect(res.statusCode).toBe(401);
+    });
+
+    test("GET /api/admin/getuser requires admin token", async () => {
+      const res = await request(app).get("/api/admin/getuser");
+      expect(res.statusCode).toBe(401);
+    });
+
+    test("DELETE /api/admin/problems/:id requires admin token", async () => {
+      const res = await request(app).delete("/api/admin/problems/noauth");
+      expect(res.statusCode).toBe(401);
+    });
+
+    test("POST /api/admin/createquestion requires admin token", async () => {
+      const res = await request(app).post("/api/admin/createquestion");
+      expect(res.statusCode).toBe(401);
+    });
+
+    test("GET /api/admin/problems/:id requires admin token", async () => {
+      const res = await request(app).get("/api/admin/problems/noauth");
+      expect(res.statusCode).toBe(401);
+    });
+
+    test("GET /api/admin/unverifiedprofs requires admin token", async () => {
+      const res = await request(app).get("/api/admin/unverifiedprofs");
+      expect(res.statusCode).toBe(401);
+    });
+
+    test("POST /api/admin/verifyprof/:id requires admin token", async () => {
+      const res = await request(app).post("/api/admin/verifyprof/noauth");
+      expect(res.statusCode).toBe(401);
+    });
+
+})

--- a/backend/middleware/adminMiddleware.js
+++ b/backend/middleware/adminMiddleware.js
@@ -1,0 +1,62 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Mina G.
+//  File:          adminMiddleware.js
+//  Description:   Express middleware that checks for an admin
+//                 key to protect routes.
+//
+//  Dependencies:  errorHandler
+//
+////////////////////////////////////////////////////////////////
+
+const { AppError } = require("../middleware/errorHandler");
+
+// Ensure ADMIN_KEY env variable set
+if (!process.env.ADMIN_KEY)
+{
+    throw new Error("ADMIN_KEY environment variable not configured");
+}
+
+/**
+ * Middleware to protect Express routes by checking for a secret key.
+ *
+ * If key is valid, TODO
+ * If missing/invalid, responds with 401 Unauthorized.
+ *
+ * @param {import('express').Request}      req  - Express request object
+ * @param {import('express').Response}     res  - Express response object
+ * @param {import('express').NextFunction} next - Next middleware function
+ *
+ * @returns {void} Sends 401 response or calls next()
+ */
+const adminMiddleware = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+
+  // 401 Unauthorized if improper token, case insensitive
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer "))
+  {
+    throw new AppError("Unauthorized access attempt: Improper token", 401, "Unauthorized");
+  }
+
+  const token = authHeader.split(" ")[1].trim();
+
+  // Validate token is present
+  if (!token)
+  {
+    throw new AppError("Unauthorized access attempt: Missing token", 401, "Unauthorized");
+  }
+
+  // Compare to admin key, 401 Unauthorized doesn't match
+  if (token === process.env.ADMIN_KEY)
+  {
+    next();
+  }
+  else
+  {
+    throw new AppError("Unauthorized access attempt: Improper token", 401, "Unauthorized");
+  }
+}
+
+module.exports = adminMiddleware;

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -299,7 +299,7 @@ router.get('/unverifiedprofs', adminMiddleware, asyncHandler(async (req, res) =>
 
 /**
  * @route   POST /api/admin/verifyprof/:id
- * @desc    Fetch a list of unverified professors
+ * @desc    Verify a professor by ID
  * @access  Admin
  * 
  * @param {import('express').Request}  req - Express request object

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -304,7 +304,7 @@ router.get('/unverifiedprofs', adminMiddleware, asyncHandler(async (req, res) =>
  * 
  * @param {import('express').Request}  req - Express request object
  * @param {import('express').Response} res - Express response object
- * @returns {Promise<void>} - JSON response with question and its answers
+ * @returns {Promise<void>} - JSON response with professor verification status message
  */
 router.post('/verifyprof/:id', adminMiddleware, asyncHandler(async (req, res) => {
   const { id } = req.params;

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -293,7 +293,7 @@ router.get('/unverifiedprofs', adminMiddleware, asyncHandler(async (req, res) =>
     'SELECT * FROM Professor WHERE VERIFIED = 0'
   );
 
-  res.json({...profs});
+  res.json({profs});
   
 }));
 

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -173,6 +173,11 @@ router.post("/createquestion", adminMiddleware, asyncHandler(async (req, res) =>
     throw new AppError("Missing required fields", 400, "Invalid fields");
   }
 
+  if (!(answer_correctness.length === answer_priority.length && answer_correctness.length === answer_text.length))
+  {
+    throw new AppError("Answer arrays are not equal length.", 400, "Invalid fields");
+  }
+
   const [result] = await req.db.query(
     'INSERT INTO Question (TYPE, AUTHOR_EXAM_ID, SECTION, CATEGORY, SUBCATEGORY, POINTS_POSSIBLE, QUESTION_TEXT, OWNER_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
     [type, author_exam_id, section, category, subcategory, points_possible, question_text, owner_id]

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -235,7 +235,7 @@ const { id } = req.params;
  * @returns {Promise<void>} - JSON response with question and its answers
  */
 router.get('/getuser', adminMiddleware, asyncHandler(async (req, res) => {
-  const { id, username } = req.body;
+  const { id, username } = req.query;
 
   // Find user by ID
   if (username == null)

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -320,7 +320,7 @@ router.post('/verifyprof/:id', adminMiddleware, asyncHandler(async (req, res) =>
     [id]
   );
 
-  res.json({...profs});
+  res.json({ message: "Professor verified successfully" });
   
 }));
 

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -1,0 +1,327 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2025-2026
+//  Author(s):     Mina G.
+//  File:          adminRoutes.js
+//  Description:   Admin routes for TODO
+//
+//  Dependencies:  mysql2 connection pool (req.db)
+//                 bcryptjs
+//                 otp-generator
+//                 errorHandler
+//
+////////////////////////////////////////////////////////////////
+
+const express = require("express");
+const bcrypt = require("bcryptjs");
+const router = express.Router();
+
+const { asyncHandler, AppError } = require('../middleware/errorHandler');
+const adminMiddleware = require("../middleware/adminMiddleware");
+
+/**
+ * Helper function, gets answers for a given question
+ * @param {number} questionId - Question ID
+ * @param {Object} db         - Database connection pool
+ * @returns {Promise<Array>}  - Array of answers
+ */
+const getAnswersForQuestion = async (questionId, db) => {
+  const [answers] = await db.query(
+    'SELECT * FROM AnswerText WHERE QUESTION_ID = ?',
+    [questionId]
+  );
+  return answers;
+};
+
+/**
+ * @route   DELETE /api/admin/user/:id
+ * @desc    Delete a user's account and associated data
+ * @access  Admin
+ */
+router.delete("/users/:id", adminMiddleware, asyncHandler(async (req, res) => {
+  const userId = req.params.id;
+
+  // Ensure userId is a valid primary key
+  if (isNaN(parseInt(userId)) || parseInt(userId) <= 0)
+  {
+    throw new AppError(`Failed to delete user, userId not a valid primary key: ${userId}`, 400, "Invalid user ID");
+  }
+
+  // Get user info
+  const [users] = await req.db.query(
+    'SELECT * FROM User WHERE ID = ?',
+    [userId]
+  );
+
+  if (users.length === 0)
+  { 
+    throw new AppError(`Failed to delete user, userId not found: ${userId}`, 404, "User not found");
+  }
+
+  const user = users[0];
+
+  // Delete user and associated email code/answers
+  await req.db.query('DELETE FROM User WHERE ID = ?', [userId]);
+  await req.db.query('DELETE FROM EmailCode WHERE EMAIL = ?', [user.EMAIL]);
+  await req.db.query('DELETE FROM Response WHERE USERID = ?', [userId]);
+  console.log(`User ${userId} and all associated data deleted successfully`);
+
+  return res
+    .status(200)
+    .json({ message: "Account deleted successfully" });
+}));
+
+
+/**
+ * @route   DELETE /api/admin/problems/:id
+ * @desc    Delete a question and associated data
+ * @access  Admin
+ */
+router.delete("/problems/:id", adminMiddleware, asyncHandler(async (req, res) => {
+  const questionId = req.params.id;
+
+  // Ensure userId is a valid primary key
+  if (isNaN(parseInt(questionId)) || parseInt(questionId) <= 0)
+  {
+    throw new AppError(`Failed to delete question, questionId not a valid primary key: ${questionId}`, 400, "Invalid question ID");
+  }
+
+  // Get user info
+  const [questions] = await req.db.query(
+    'SELECT * FROM Question WHERE ID = ?',
+    [questionId]
+  );
+
+  if (questions.length === 0)
+  { 
+    throw new AppError(`Failed to delete question, questionId not found: ${questionId}`, 404, "Question not found");
+  }
+
+  const question = questions[0];
+
+  // Delete user and associated email code/answers
+  await req.db.query('DELETE FROM Question WHERE ID = ?', [questionId]);
+  await req.db.query('DELETE FROM AnswerText WHERE QUESTION_ID = ?', [questionId]);
+  await req.db.query('DELETE FROM Response WHERE PROBLEM_ID = ?', [questionId]);
+  console.log(`Question ${questionId} and all associated data deleted successfully`);
+
+  return res
+    .status(200)
+    .json({ message: "Question deleted successfully" });
+}));
+
+
+/**
+ * @route   POST /api/admin/createuser
+ * @desc    Allows an admin to create an accout bypassing verification
+ * @access  Admin
+ * 
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>} - JSON response to confirm successful submission
+ */
+router.post("/createuser", adminMiddleware, asyncHandler(async(req, res) => {
+  const { username, email, password, firstName, lastName } = req.body;
+  
+  if (!username || !email || !password || !firstName || !lastName) 
+  {
+    throw new AppError("Missing required fields", 400, "Invalid fields");
+  }
+  
+  // Check if user already exists
+  const [existingUsers] = await req.db.query(
+    'SELECT * FROM User WHERE USERNAME = ?', 
+    [username]
+  );
+
+  if (existingUsers.length > 0)
+  {
+    throw new AppError(`User "${username}" or email "${email}" already exists`, 400, "User or email already exists");
+  }
+
+  const salt = await bcrypt.genSalt(10);
+  const hashedPassword = await bcrypt.hash(password, salt);
+
+  // Insert new user into db
+  const [result] = await req.db.query(
+    'INSERT INTO User (USERNAME, EMAIL, PASSWORD, FIRSTNAME, LASTNAME) VALUES (?, ?, ?, ?, ?)',
+    [username, email, hashedPassword, firstName, lastName]
+  );
+
+  const userId = result.insertId;
+
+  res.status(201).json({ message: "User Registered", userId});
+
+}));
+module.exports = router;
+
+/**
+ * @route   POST /api/admin/createquestion
+ * @desc    Create a new question object and a certain number of corresponding answer_text objects
+ * @access  Admin
+ * 
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>} - JSON response to confirm successful submission
+ */
+router.post("/createquestion", adminMiddleware, asyncHandler(async (req, res) => {
+  const { type, author_exam_id, section, category, subcategory, points_possible, question_text, owner_id, answer_text, answer_correctness, answer_priority } = req.body;
+
+  if (!type || !author_exam_id || !section || !category || !subcategory || !points_possible || !question_text || !answer_text || !answer_correctness || !answer_priority)
+  {
+    throw new AppError("Missing required fields", 400, "Invalid fields");
+  }
+
+  const [result] = await req.db.query(
+    'INSERT INTO Question (TYPE, AUTHOR_EXAM_ID, SECTION, CATEGORY, SUBCATEGORY, POINTS_POSSIBLE, QUESTION_TEXT, OWNER_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    [type, author_exam_id, section, category, subcategory, points_possible, question_text, owner_id]
+  );
+
+  const questionId = result.insertId;
+
+  if (questionId)
+  {
+    for (let i = 0; i < answer_text.length; i++)
+    {
+      await req.db.query(
+        'INSERT INTO AnswerText (QUESTION_ID, IS_CORRECT_ANSWER, TEXT, PRIORITY) VALUES (?, ?, ?, ?)',
+        [questionId, answer_correctness[i], answer_text[i], answer_priority[i]]
+      );
+    }
+  }
+
+  res.status(201).json({ message: "Question added", questionId});
+}));
+
+/**
+ * @route   GET /api/admin/problems/:id
+ * @desc    Fetch a question by its ID with its associated answers
+ * @access  Admin
+ * 
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>} - JSON response with question and its answers
+ */
+router.get('/problems/:id', adminMiddleware, asyncHandler(async (req, res) => {
+const { id } = req.params;
+
+  // Find question by ID
+  const [questions] = await req.db.query(
+    'SELECT * FROM Question WHERE ID = ?',
+    [id]
+  );
+
+  if (questions.length === 0) 
+  {
+    throw new AppError(`No questions associated with ID: ${id}`, 404, "Question not found");
+  }
+
+  const question = questions[0];
+
+  // Get answers for question
+  const answers = await getAnswersForQuestion(id, req.db);
+
+  res.json({...question, answers});
+}));
+
+/**
+ * @route   GET /api/admin/getuser
+ * @desc    Fetch a user by its ID or username
+ * @access  Admin
+ * 
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>} - JSON response with question and its answers
+ */
+router.get('/getuser', adminMiddleware, asyncHandler(async (req, res) => {
+  const { id, username } = req.body;
+
+  // Find user by ID
+  if (username == null)
+  {
+  const [users] = await req.db.query(
+    'SELECT * FROM User WHERE ID = ?',
+    [id]
+  );
+
+  if (users.length === 0) 
+  {
+    throw new AppError(`No users associated with ID: ${id}`, 404, "User not found");
+  }
+  
+  const user = users[0];
+
+
+  res.json({...user});
+  }
+
+  // find user by username
+  else if (id == null)
+  {
+  const [users] = await req.db.query(
+    'SELECT * FROM User WHERE USERNAME = ?',
+    [username]
+  );
+
+  if (users.length === 0) 
+  {
+    throw new AppError(`No users associated with username: ${username}`, 404, "User not found");
+  }
+
+  const user = users[0];
+
+
+  res.json({...user});
+  }
+
+  
+}));
+
+/**
+ * @route   GET /api/admin/unverifiedprofs
+ * @desc    Fetch a list of unverified professors
+ * @access  Admin
+ * 
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>} - JSON response with question and its answers
+ */
+router.get('/unverifiedprofs', adminMiddleware, asyncHandler(async (req, res) => {
+  
+  const [profs] = await req.db.query(
+    'SELECT * FROM Professor WHERE VERIFIED = 0'
+  );
+
+  res.json({...profs});
+  
+}));
+
+/**
+ * @route   POST /api/admin/verifyprof/:id
+ * @desc    Fetch a list of unverified professors
+ * @access  Admin
+ * 
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>} - JSON response with question and its answers
+ */
+router.post('/verifyprof/:id', adminMiddleware, asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  // Ensure id is a valid primary key
+  if (isNaN(parseInt(id)) || parseInt(id) <= 0)
+  {
+    throw new AppError(`Failed to verify professor, id not a valid primary key: ${id}`, 400, "Invalid professor ID");
+  }
+
+  const [profs] = await req.db.query(
+    'UPDATE Professor SET VERIFIED = 1 WHERE ID = ?',
+    [id]
+  );
+
+  res.json({...profs});
+  
+}));
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -108,6 +108,7 @@ app.use('/api/progress', require('./routes/myProgress'));
 app.use('/api/problems', require('./routes/problems'));
 app.use('/api/test', require('./routes/testRoutes'));
 app.use('/api/users', require('./routes/users'));
+app.use('/api/admin', require('./routes/adminRoutes'));
 
 // Error handler
 app.use(handleError);


### PR DESCRIPTION
This PR addresses [SCRUM-119: Admin API Endpoints](https://knightwise.atlassian.net/browse/SCRUM-119?atlOrigin=eyJpIjoiMjIyMWZjYWVhMTVhNDFlMTliZjFkZTQwODA1OGFjNTYiLCJwIjoiaiJ9).

This PR includes 8 new API endpoints for the purpose of carrying out the moderation actions listed [in this document](https://docs.google.com/document/d/1lbQDmj_6JTAvFGNtJIaUofU7esJsJ6ycx7-ptvMo5UU/edit?usp=sharing). This includes retrieval, creation, and deletion for question and user objects, as well as verification for professor objects.

These endpoints use a separate middle-ware for authorization, accepting only bearers with a key that matches the ADMIN_KEY environment variable. Using the Discord bot in [this repository](https://github.com/KnightWiseUCF/kw-dev-bot) with a matching key, administrators can call these endpoints as necessary.

The following screenshot shows the unit tests for these endpoints. Every endpoint is tested for a valid outcome, and then tested for authorization strictness:
<img width="919" height="1034" alt="unittestsadmin" src="https://github.com/user-attachments/assets/6c0fde3c-04a9-4a67-abf5-2e28d2f41624" />