### PR TITLE
SCRUM-164: Add Run Functionality to Programming Questions

### DIFF
--- a/backend/config/codeLimits.js
+++ b/backend/config/codeLimits.js
@@ -16,6 +16,10 @@ const MAX_CODE_BYTES = 10000;
 // Judge0's free cloud tier supports 50 free code submissions per day.
 const MAX_SUBMISSIONS_PER_DAY = 10;
 
+// Maximum allowed test runs per problem for an individual user
+// Resets per problem daily
+const MAX_TEST_RUNS_PER_PROBLEM = 3;
+
 /*
  * Judge0 already enforces the following runtime and memory limits:
  *   cpu_time_limit :5
@@ -33,6 +37,7 @@ const MAX_SUBMISSIONS_PER_DAY = 10;
 module.exports = {
     MAX_CODE_BYTES,
     MAX_SUBMISSIONS_PER_DAY,
+    MAX_TEST_RUNS_PER_PROBLEM,
     // MAX_RUNTIME_MS,
     // MAX_MEMORY_KB
 }

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE `AnswerText` (
   PRIMARY KEY (`ID`),
   KEY `QUESTION_ID` (`QUESTION_ID`),
   CONSTRAINT `AnswerText_ibfk_1` FOREIGN KEY (`QUESTION_ID`) REFERENCES `Question` (`ID`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=279 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=731 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `EmailCode`;
@@ -68,11 +68,11 @@ CREATE TABLE `Question` (
   `POINTS_POSSIBLE` decimal(5,2) DEFAULT NULL,
   `QUESTION_TEXT` text,
   `OWNER_ID` int DEFAULT NULL,
-  `IS_PUBLISHED` smallint NOT NULL DEFAULT 1,
+  `IS_PUBLISHED` smallint NOT NULL DEFAULT '1',
   PRIMARY KEY (`ID`),
   KEY `FK_Question_Owner` (`OWNER_ID`),
   CONSTRAINT `FK_Question_Owner` FOREIGN KEY (`OWNER_ID`) REFERENCES `User` (`ID`) ON DELETE SET NULL
-) ENGINE=InnoDB AUTO_INCREMENT=68 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=201 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `Response`;
@@ -94,7 +94,7 @@ CREATE TABLE `Response` (
   KEY `PROBLEM_ID` (`PROBLEM_ID`),
   CONSTRAINT `Response_ibfk_1` FOREIGN KEY (`USERID`) REFERENCES `User` (`ID`) ON DELETE CASCADE,
   CONSTRAINT `Response_ibfk_2` FOREIGN KEY (`PROBLEM_ID`) REFERENCES `Question` (`ID`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=133 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=343 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `TestCase`;
@@ -108,6 +108,22 @@ CREATE TABLE `TestCase` (
   PRIMARY KEY (`ID`),
   KEY `idx_question_id` (`QUESTION_ID`),
   CONSTRAINT `TestCase_ibfk_1` FOREIGN KEY (`QUESTION_ID`) REFERENCES `Question` (`ID`) ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=26 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `TestRun`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `TestRun` (
+  `ID` int NOT NULL AUTO_INCREMENT,
+  `USERID` int NOT NULL,
+  `QUESTION_ID` int NOT NULL,
+  `DATETIME` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`ID`),
+  KEY `USERID` (`USERID`),
+  KEY `PROBLEM_ID` (`QUESTION_ID`),
+  CONSTRAINT `TestRun_ibfk_1` FOREIGN KEY (`USERID`) REFERENCES `User` (`ID`) ON DELETE CASCADE,
+  CONSTRAINT `TestRun_ibfk_2` FOREIGN KEY (`QUESTION_ID`) REFERENCES `Question` (`ID`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -205,6 +205,44 @@ paths:
           description: URL Not Found
         500:
           description: Server Error
+
+  /code/submitCode:
+    post:
+      tags:
+      - Problems
+      summary: Submit or test code against a programming question.
+      operationId: submitCode
+      description: |
+        Submits code to Judge0 for execution. Supports two modes:
+        - **Graded Submission** (`isTestRun: false`): Runs code against all test cases, grades the result, and records the response. Counts toward the daily submission limit (10/day).
+        - **Test Run** (`isTestRun: true`): Runs code against only the first test case and returns raw output without grading or saving a response. Limited to 3 runs per problem per day.
+      security:
+        - BearerAuth: []
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: submitCodeItem
+        description: Code submission details.
+        schema:
+          $ref: '#/definitions/SubmitCode'
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request
+        401:
+          description: Unauthorized
+        404:
+          description: Question or Test Cases Not Found
+        429:
+          description: Submission or Test Run Limit Exceeded
+        500:
+          description: Server Error
+        502:
+          description: Judge0 Service Unavailable
   
   /test/topic/{topicName}:
     get:
@@ -446,6 +484,31 @@ definitions:
       password:
         type: string
         example: "newPass123!"
+
+  SubmitCode:
+    type: object
+    required:
+    - problemId
+    - code
+    - languageId
+    - isTestRun
+    properties:
+      problemId:
+        type: integer
+        example: 42
+        description: The unique ID of the programming question.
+      code:
+        type: string
+        example: "print('Hello World')"
+        description: The code to execute.
+      languageId:
+        type: integer
+        example: 71
+        description: Judge0 language ID for the submitted code.
+      isTestRun:
+        type: boolean
+        example: false
+        description: If true, runs against first test case only without grading or saving. If false, runs full graded submission.
   
   SubmitAnswer:
     type: object

--- a/backend/test-report.html
+++ b/backend/test-report.html
@@ -274,7 +274,7 @@ header {
   font-size: 1rem;
   padding: 0 0.5rem;
 }
-</style></head><body><main class="jesthtml-content"><header><h1 id="title">Test Report</h1></header><section id="metadata-container"><div id="timestamp">Started: 2026-02-14 00:18:09</div><div id="summary"><div id="suite-summary"><div class="summary-total">Suites (3)</div><div class="summary-passed ">3 passed</div><div class="summary-failed  summary-empty">0 failed</div><div class="summary-pending  summary-empty">0 pending</div></div><div id="test-summary"><div class="summary-total">Tests (35)</div><div class="summary-passed ">35 passed</div><div class="summary-failed  summary-empty">0 failed</div><div class="summary-pending  summary-empty">0 pending</div></div></div></section><details id="suite-1" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/code.test.js</div><div class="suite-time warn">11.971s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should require auth token</div><div class="test-status">passed</div><div class="test-duration">0.121s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject missing code field</div><div class="test-status">passed</div><div class="test-duration">0.197s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject empty code field</div><div class="test-status">passed</div><div class="test-duration">0.206s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject missing languageId field</div><div class="test-status">passed</div><div class="test-duration">0.203s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject code exceeding max code length</div><div class="test-status">passed</div><div class="test-duration">0.197s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject code exceeding max daily submissions</div><div class="test-status">passed</div><div class="test-duration">0.708s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject invalid language ID</div><div class="test-status">passed</div><div class="test-duration">0.202s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject when problem not found</div><div class="test-status">passed</div><div class="test-duration">0.304s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Successful Execution Tests</div><div class="test-title">should accept correct code and return success</div><div class="test-status">passed</div><div class="test-duration">0.493s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Successful Execution Tests</div><div class="test-title">should detect wrong output</div><div class="test-status">passed</div><div class="test-duration">0.488s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Successful Execution Tests</div><div class="test-title">should save submission to database</div><div class="test-status">passed</div><div class="test-duration">0.586s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Error Handling Tests</div><div class="test-title">should handle compilation errors</div><div class="test-status">passed</div><div class="test-duration">0.432s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Error Handling Tests</div><div class="test-title">should handle runtime errors</div><div class="test-status">passed</div><div class="test-duration">0.619s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Error Handling Tests</div><div class="test-title">should handle Judge0 service failures</div><div class="test-status">passed</div><div class="test-duration">0.392s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Test Case Tests</div><div class="test-title">should pass all test cases and award full points</div><div class="test-status">passed</div><div class="test-duration">0.492s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Test Case Tests</div><div class="test-title">should award partial credit when some tests fail</div><div class="test-status">passed</div><div class="test-duration">0.525s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Test Case Tests</div><div class="test-title">should award zero points when all tests fail</div><div class="test-status">passed</div><div class="test-duration">0.541s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Language Support</div><div class="test-title">should execute Python code</div><div class="test-status">passed</div><div class="test-duration">0.469s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Language Support</div><div class="test-title">should execute C code</div><div class="test-status">passed</div><div class="test-duration">0.482s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Language Support</div><div class="test-title">should execute C++ code</div><div class="test-status">passed</div><div class="test-duration">0.593s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Language Support</div><div class="test-title">should execute Java code</div><div class="test-status">passed</div><div class="test-duration">0.489s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
+</style></head><body><main class="jesthtml-content"><header><h1 id="title">Test Report</h1></header><section id="metadata-container"><div id="timestamp">Started: 2026-02-20 15:45:52</div><div id="summary"><div id="suite-summary"><div class="summary-total">Suites (9)</div><div class="summary-passed ">9 passed</div><div class="summary-failed  summary-empty">0 failed</div><div class="summary-pending  summary-empty">0 pending</div></div><div id="test-summary"><div class="summary-total">Tests (101)</div><div class="summary-passed ">101 passed</div><div class="summary-failed  summary-empty">0 failed</div><div class="summary-pending  summary-empty">0 pending</div></div></div></section><details id="suite-1" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/code.test.js</div><div class="suite-time warn">9.94s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should require auth token</div><div class="test-status">passed</div><div class="test-duration">0.1s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject missing code field</div><div class="test-status">passed</div><div class="test-duration">0.097s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject empty code field</div><div class="test-status">passed</div><div class="test-duration">0.085s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject missing languageId field</div><div class="test-status">passed</div><div class="test-duration">0.089s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject code exceeding max code length</div><div class="test-status">passed</div><div class="test-duration">0.099s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject code exceeding max daily submissions</div><div class="test-status">passed</div><div class="test-duration">0.365s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject invalid language ID</div><div class="test-status">passed</div><div class="test-duration">0.1s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Validation Tests</div><div class="test-title">should reject when problem not found</div><div class="test-status">passed</div><div class="test-duration">0.188s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Successful Execution Tests</div><div class="test-title">should accept correct code and return success</div><div class="test-status">passed</div><div class="test-duration">0.267s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Successful Execution Tests</div><div class="test-title">should detect wrong output</div><div class="test-status">passed</div><div class="test-duration">0.282s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Successful Execution Tests</div><div class="test-title">should save submission to database</div><div class="test-status">passed</div><div class="test-duration">0.3s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Error Handling Tests</div><div class="test-title">should handle compilation errors</div><div class="test-status">passed</div><div class="test-duration">0.309s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Error Handling Tests</div><div class="test-title">should handle runtime errors</div><div class="test-status">passed</div><div class="test-duration">0.298s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Error Handling Tests</div><div class="test-title">should handle Judge0 service failures</div><div class="test-status">passed</div><div class="test-duration">0.268s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Test Case Tests</div><div class="test-title">should pass all test cases and award full points</div><div class="test-status">passed</div><div class="test-duration">0.258s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Test Case Tests</div><div class="test-title">should award partial credit when some tests fail</div><div class="test-status">passed</div><div class="test-duration">0.252s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Test Case Tests</div><div class="test-title">should award zero points when all tests fail</div><div class="test-status">passed</div><div class="test-duration">0.26s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Language Support</div><div class="test-title">should execute Python code</div><div class="test-status">passed</div><div class="test-duration">0.257s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Language Support</div><div class="test-title">should execute C code</div><div class="test-status">passed</div><div class="test-duration">0.271s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Language Support</div><div class="test-title">should execute C++ code</div><div class="test-status">passed</div><div class="test-duration">0.262s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Multi-Language Support</div><div class="test-title">should execute Java code</div><div class="test-status">passed</div><div class="test-duration">0.263s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Test Run Tests</div><div class="test-title">should return stdout without grading or saving a Response</div><div class="test-status">passed</div><div class="test-duration">0.309s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Test Run Tests</div><div class="test-title">should save a TestRun entry to the database</div><div class="test-status">passed</div><div class="test-duration">0.297s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Test Run Tests</div><div class="test-title">should only submit first test case to Judge0 on test run</div><div class="test-status">passed</div><div class="test-duration">0.268s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Test Run Tests</div><div class="test-title">should not count test runs against actual submission limit</div><div class="test-status">passed</div><div class="test-duration">0.3s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Test Run Tests</div><div class="test-title">should not count actual submissions against test run limit</div><div class="test-status">passed</div><div class="test-duration">0.311s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Test Run Tests</div><div class="test-title">should reject when test run limit exceeded</div><div class="test-status">passed</div><div class="test-duration">0.187s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Test Run Tests</div><div class="test-title">should handle compilation errors on test run</div><div class="test-status">passed</div><div class="test-duration">0.297s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">POST /api/code/submitCode &gt; Test Run Tests</div><div class="test-title">should reject missing isTestRun field</div><div class="test-status">passed</div><div class="test-duration">0.103s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
     at Runtime._execModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1439:24)
     at Runtime._loadModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1022:12)
     at Runtime.requireModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:882:12)
@@ -336,9 +336,46 @@ header {
     at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
     at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
     at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
-    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Empty problemId, code, or languageId
-    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:128:11
-    at processTicksAndRejections (node:internal/process/task_queues:105:5) {
+    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Empty problemId, code, languageId, or isTestRun
+    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:112:11
+    at fn (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:47:21)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at next (/root/code/KW_Workspace/knightwise/backend/middleware/authMiddleware.js:60:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/read.js:137:5
+    at AsyncResource.runInAsyncScope (node:async_hooks:211:14)
+    at invokeCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:238:16)
+    at done (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:227:7)
+    at IncomingMessage.onEnd (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:287:7)
+    at IncomingMessage.emit (node:events:518:28)
+    at endReadableNT (node:internal/streams/readable:1698:12)
+    at processTicksAndRejections (node:internal/process/task_queues:90:21) {
   statusCode: 400,
   userMessage: 'Missing required fields.'
 }</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
@@ -348,9 +385,46 @@ header {
     at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
     at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
     at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
-    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Empty problemId, code, or languageId
-    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:128:11
-    at processTicksAndRejections (node:internal/process/task_queues:105:5) {
+    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Empty problemId, code, languageId, or isTestRun
+    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:112:11
+    at fn (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:47:21)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at next (/root/code/KW_Workspace/knightwise/backend/middleware/authMiddleware.js:60:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/read.js:137:5
+    at AsyncResource.runInAsyncScope (node:async_hooks:211:14)
+    at invokeCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:238:16)
+    at done (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:227:7)
+    at IncomingMessage.onEnd (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:287:7)
+    at IncomingMessage.emit (node:events:518:28)
+    at endReadableNT (node:internal/streams/readable:1698:12)
+    at processTicksAndRejections (node:internal/process/task_queues:90:21) {
   statusCode: 400,
   userMessage: 'Missing required fields.'
 }</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
@@ -360,9 +434,46 @@ header {
     at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
     at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
     at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
-    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Empty problemId, code, or languageId
-    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:128:11
-    at processTicksAndRejections (node:internal/process/task_queues:105:5) {
+    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Empty problemId, code, languageId, or isTestRun
+    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:112:11
+    at fn (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:47:21)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at next (/root/code/KW_Workspace/knightwise/backend/middleware/authMiddleware.js:60:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/read.js:137:5
+    at AsyncResource.runInAsyncScope (node:async_hooks:211:14)
+    at invokeCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:238:16)
+    at done (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:227:7)
+    at IncomingMessage.onEnd (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:287:7)
+    at IncomingMessage.emit (node:events:518:28)
+    at endReadableNT (node:internal/streams/readable:1698:12)
+    at processTicksAndRejections (node:internal/process/task_queues:90:21) {
   statusCode: 400,
   userMessage: 'Missing required fields.'
 }</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
@@ -373,8 +484,45 @@ header {
     at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
     at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
     at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Code submission too long, exceeds 10000 bytes
-    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:134:11
-    at processTicksAndRejections (node:internal/process/task_queues:105:5) {
+    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:118:11
+    at fn (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:47:21)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at next (/root/code/KW_Workspace/knightwise/backend/middleware/authMiddleware.js:60:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/read.js:137:5
+    at AsyncResource.runInAsyncScope (node:async_hooks:211:14)
+    at invokeCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:238:16)
+    at done (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:227:7)
+    at IncomingMessage.onEnd (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:287:7)
+    at IncomingMessage.emit (node:events:518:28)
+    at endReadableNT (node:internal/streams/readable:1698:12)
+    at processTicksAndRejections (node:internal/process/task_queues:90:21) {
   statusCode: 400,
   userMessage: 'Code submission too long.'
 }</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
@@ -384,8 +532,8 @@ header {
     at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
     at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
     at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
-    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: User 49 has 10 daily submissions, exceeds max
-    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:117:11
+    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: User 69 has 10 daily submissions, exceeds max
+    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:166:13
     at processTicksAndRejections (node:internal/process/task_queues:105:5) {
   statusCode: 429,
   userMessage: 'Daily submission limit exceeded.'
@@ -397,8 +545,45 @@ header {
     at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
     at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
     at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: languageId unsupported by KnightWise: 999
-    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:145:11
-    at processTicksAndRejections (node:internal/process/task_queues:105:5) {
+    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:129:11
+    at fn (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:47:21)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at next (/root/code/KW_Workspace/knightwise/backend/middleware/authMiddleware.js:60:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/read.js:137:5
+    at AsyncResource.runInAsyncScope (node:async_hooks:211:14)
+    at invokeCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:238:16)
+    at done (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:227:7)
+    at IncomingMessage.onEnd (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:287:7)
+    at IncomingMessage.emit (node:events:518:28)
+    at endReadableNT (node:internal/streams/readable:1698:12)
+    at processTicksAndRejections (node:internal/process/task_queues:90:21) {
   statusCode: 400,
   userMessage: 'Unsupported programming language.'
 }</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
@@ -409,7 +594,7 @@ header {
     at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
     at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
     at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: No programming question found: ID 99999
-    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:159:11
+    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:181:11
     at processTicksAndRejections (node:internal/process/task_queues:105:5) {
   statusCode: 404,
   userMessage: 'Programming question not found.'
@@ -421,7 +606,7 @@ header {
     at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
     at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
     at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Judge0 API unavailable
-    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/__test__/code.test.js:405:9)
+    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/__test__/code.test.js:444:9)
     at Promise.then.completed (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-circus/build/utils.js:298:28)
     at new Promise (&lt;anonymous&gt;)
     at callAsyncCircusFn (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-circus/build/utils.js:231:10)
@@ -438,7 +623,1118 @@ header {
     at runTest (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:444:34) {
   statusCode: 502,
   userMessage: 'Code submission failed.'
-}</pre></div></div></details><details id="suite-2" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/auth.test.js</div><div class="suite-time warn">6.532s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">sendotp -  send OTP for signup</div><div class="test-status">passed</div><div class="test-duration">0.589s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">sendotp -  fail if email is already registered during signup</div><div class="test-status">passed</div><div class="test-duration">0.439s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">sendotp -  fail if user does not exist during reset</div><div class="test-status">passed</div><div class="test-duration">0.365s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">verify -  verify correct OTP</div><div class="test-status">passed</div><div class="test-duration">0.593s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">verify -  fail with wrong OTP</div><div class="test-status">passed</div><div class="test-duration">0.434s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">verify -  fail if OTP expired</div><div class="test-status">passed</div><div class="test-duration">0.509s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">verify -  fail if no OTP record found</div><div class="test-status">passed</div><div class="test-duration">0.405s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">signup -  succeed if email verified</div><div class="test-status">passed</div><div class="test-duration">0.715s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">login -  login with correct credentials</div><div class="test-status">passed</div><div class="test-duration">0.724s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">resetPassword -  reset password after verify</div><div class="test-status">passed</div><div class="test-duration">1.027s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
+    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: User 69 has 3 test runs for question 309, exceeds max
+    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:146:13
+    at processTicksAndRejections (node:internal/process/task_queues:105:5) {
+  statusCode: 429,
+  userMessage: 'Daily test run limit for this question exceeded.'
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
+    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Empty problemId, code, languageId, or isTestRun
+    at /root/code/KW_Workspace/knightwise/backend/controllers/codeController.js:112:11
+    at fn (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:47:21)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at next (/root/code/KW_Workspace/knightwise/backend/middleware/authMiddleware.js:60:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/read.js:137:5
+    at AsyncResource.runInAsyncScope (node:async_hooks:211:14)
+    at invokeCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:238:16)
+    at done (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:227:7)
+    at IncomingMessage.onEnd (/root/code/KW_Workspace/knightwise/backend/node_modules/raw-body/index.js:287:7)
+    at IncomingMessage.emit (node:events:518:28)
+    at endReadableNT (node:internal/streams/readable:1698:12)
+    at processTicksAndRejections (node:internal/process/task_queues:90:21) {
+  statusCode: 400,
+  userMessage: 'Missing required fields.'
+}</pre></div></div></details><details id="suite-2" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/admin.test.js</div><div class="suite-time warn">5.57s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">GET /api/admin/getuser gets a user with an id</div><div class="test-status">passed</div><div class="test-duration">0.305s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">GET /api/admin/getuser gets a user with a username</div><div class="test-status">passed</div><div class="test-duration">0.313s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">POST /api/admin/createuser creates a new user</div><div class="test-status">passed</div><div class="test-duration">0.476s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">DELETE /api/admin/users/:id deletes a user</div><div class="test-status">passed</div><div class="test-duration">0.422s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">GET /api/admin/problems/:id retieves a question</div><div class="test-status">passed</div><div class="test-duration">0.328s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">POST /api/admin/createquestion creates a question</div><div class="test-status">passed</div><div class="test-duration">0.29s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">DELETE /api/admin/problems/:id deletes a question</div><div class="test-status">passed</div><div class="test-duration">0.409s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">GET /api/admin/unverifiedprofs returns unverified profs</div><div class="test-status">passed</div><div class="test-duration">0.295s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">POST /api/admin/verifyprof/:id verifies a prof</div><div class="test-status">passed</div><div class="test-duration">0.297s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">DELETE /api/admin/users/:id requires admin token</div><div class="test-status">passed</div><div class="test-duration">0.224s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">POST /api/admin/createuser requires admin token</div><div class="test-status">passed</div><div class="test-duration">0.21s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">GET /api/admin/getuser requires admin token</div><div class="test-status">passed</div><div class="test-duration">0.22s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">DELETE /api/admin/problems/:id requires admin token</div><div class="test-status">passed</div><div class="test-duration">0.206s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">POST /api/admin/createquestion requires admin token</div><div class="test-status">passed</div><div class="test-duration">0.212s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">GET /api/admin/problems/:id requires admin token</div><div class="test-status">passed</div><div class="test-duration">0.209s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">GET /api/admin/unverifiedprofs requires admin token</div><div class="test-status">passed</div><div class="test-duration">0.231s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Admin Routes</div><div class="test-title">POST /api/admin/verifyprof/:id requires admin token</div><div class="test-status">passed</div><div class="test-duration">0.206s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
+    at Runtime._execModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1439:24)
+    at Runtime._loadModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1022:12)
+    at Runtime.requireModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:882:12)
+    at runTestInternal (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:296:33)
+    at runTest (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:444:34)</pre><pre class="suite-consolelog-item-message">Loaded environment file: .env.test</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/server.js:76:17)
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at verifyTestDatabase (/root/code/KW_Workspace/knightwise/backend/__test__/testHelpers.js:74:3)
+    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/__test__/admin.test.js:24:3)</pre><pre class="suite-consolelog-item-message">MySQL Connected</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/__test__/testHelpers.js:91:11)
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/__test__/admin.test.js:24:3)</pre><pre class="suite-consolelog-item-message">Database check passed: Using KW_Testing</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/routes/adminRoutes.js:68:11)
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)</pre><pre class="suite-consolelog-item-message">User 73 and all associated data deleted successfully</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/routes/adminRoutes.js:107:11)
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)</pre><pre class="suite-consolelog-item-message">Question 313 and all associated data deleted successfully</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:265:14)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:141:14)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:67:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:147:13)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:97:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:365:14)
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:376:14)
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:421:3)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Unauthorized access attempt: Improper token
+    at adminMiddleware (/root/code/KW_Workspace/knightwise/backend/middleware/adminMiddleware.js:40:11)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:365:14)
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:376:14)
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:421:3)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17) {
+  statusCode: 401,
+  userMessage: 'Unauthorized'
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:265:14)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:141:14)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:67:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:147:13)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:97:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:122:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Unauthorized access attempt: Improper token
+    at adminMiddleware (/root/code/KW_Workspace/knightwise/backend/middleware/adminMiddleware.js:40:11)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:122:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17) {
+  statusCode: 401,
+  userMessage: 'Unauthorized'
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:265:14)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:141:14)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:67:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:147:13)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:97:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Unauthorized access attempt: Improper token
+    at adminMiddleware (/root/code/KW_Workspace/knightwise/backend/middleware/adminMiddleware.js:40:11)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17) {
+  statusCode: 401,
+  userMessage: 'Unauthorized'
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:265:14)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:141:14)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:67:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:147:13)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:97:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:365:14)
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:376:14)
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:421:3)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Unauthorized access attempt: Improper token
+    at adminMiddleware (/root/code/KW_Workspace/knightwise/backend/middleware/adminMiddleware.js:40:11)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:365:14)
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:376:14)
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:421:3)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17) {
+  statusCode: 401,
+  userMessage: 'Unauthorized'
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:265:14)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:141:14)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:67:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:147:13)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:97:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:122:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Unauthorized access attempt: Improper token
+    at adminMiddleware (/root/code/KW_Workspace/knightwise/backend/middleware/adminMiddleware.js:40:11)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:122:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17) {
+  statusCode: 401,
+  userMessage: 'Unauthorized'
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:265:14)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:141:14)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:67:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:147:13)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:97:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:365:14)
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:376:14)
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:421:3)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Unauthorized access attempt: Improper token
+    at adminMiddleware (/root/code/KW_Workspace/knightwise/backend/middleware/adminMiddleware.js:40:11)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:365:14)
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:376:14)
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:421:3)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17) {
+  statusCode: 401,
+  userMessage: 'Unauthorized'
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:265:14)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:141:14)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:67:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:147:13)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:97:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Unauthorized access attempt: Improper token
+    at adminMiddleware (/root/code/KW_Workspace/knightwise/backend/middleware/adminMiddleware.js:40:11)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:113:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17) {
+  statusCode: 401,
+  userMessage: 'Unauthorized'
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
+    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Unauthorized access attempt: Improper token
+    at adminMiddleware (/root/code/KW_Workspace/knightwise/backend/middleware/adminMiddleware.js:40:11)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:149:13)
+    at Route.dispatch (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/route.js:119:3)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:284:15
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:365:14)
+    at param (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:376:14)
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:421:3)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at router (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:47:12)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:104:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at next (/root/code/KW_Workspace/knightwise/backend/server.js:90:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at jsonParser (/root/code/KW_Workspace/knightwise/backend/node_modules/body-parser/lib/types/json.js:122:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at cors (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:188:7)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:224:17
+    at originCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:214:15)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:219:13
+    at optionsCallback (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:199:9)
+    at corsMiddleware (/root/code/KW_Workspace/knightwise/backend/node_modules/cors/lib/index.js:204:7)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at expressInit (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/init.js:40:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at query (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/middleware/query.js:45:5)
+    at Layer.handle [as handle_request] (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:95:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:328:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:175:3)
+    at Function.handle (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/application.js:181:10)
+    at Server.app (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/express.js:39:9)
+    at Server.emit (node:events:518:28)
+    at parserOnIncoming (node:_http_server:1153:12)
+    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17) {
+  statusCode: 401,
+  userMessage: 'Unauthorized'
+}</pre></div></div></details><details id="suite-3" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/auth.test.js</div><div class="suite-time">3.977s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">sendotp -  send OTP for signup</div><div class="test-status">passed</div><div class="test-duration">0.217s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">sendotp -  fail if email is already registered during signup</div><div class="test-status">passed</div><div class="test-duration">0.183s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">sendotp -  fail if user does not exist during reset</div><div class="test-status">passed</div><div class="test-duration">0.126s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">verify -  verify correct OTP</div><div class="test-status">passed</div><div class="test-duration">0.244s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">verify -  fail with wrong OTP</div><div class="test-status">passed</div><div class="test-duration">0.168s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">verify -  fail if OTP expired</div><div class="test-status">passed</div><div class="test-duration">0.169s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">verify -  fail if no OTP record found</div><div class="test-status">passed</div><div class="test-duration">0.121s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">signup -  succeed if email verified</div><div class="test-status">passed</div><div class="test-duration">0.356s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">login -  login with correct credentials</div><div class="test-status">passed</div><div class="test-duration">0.495s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">resetPassword -  reset password after verify</div><div class="test-status">passed</div><div class="test-duration">0.983s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Auth Routes</div><div class="test-title">resetPassword - fail if new password is same as current password</div><div class="test-status">passed</div><div class="test-duration">0.547s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
     at Runtime._execModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1439:24)
     at Runtime._loadModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1022:12)
     at Runtime.requireModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:882:12)
@@ -519,7 +1815,18 @@ header {
     at processTicksAndRejections (node:internal/process/task_queues:105:5) {
   statusCode: 400,
   userMessage: 'No record'
-}</pre></div></div></details><details id="suite-3" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/test.test.js</div><div class="suite-time warn">5.59s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename"> </div><div class="test-title">GET /api/test/topic/:topicName</div><div class="test-status">passed</div><div class="test-duration">0.769s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename"> </div><div class="test-title">GET /api/test/topic/:topicName requires auth</div><div class="test-status">passed</div><div class="test-duration">0.401s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename"> </div><div class="test-title">GET /api/test/mocktest</div><div class="test-status">passed</div><div class="test-duration">2.756s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename"> </div><div class="test-title">GET /api/test/mocktest requires auth</div><div class="test-status">passed</div><div class="test-duration">0.285s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
+}</pre></div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at log (/root/code/KW_Workspace/knightwise/backend/middleware/errorHandler.js:68:13)
+    at Layer.handle_error (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/layer.js:71:5)
+    at trim_prefix (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:326:13)
+    at /root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:286:9
+    at Function.process_params (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:346:12)
+    at Immediate.next (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:280:10)
+    at Immediate._onImmediate (/root/code/KW_Workspace/knightwise/backend/node_modules/express/lib/router/index.js:646:15)
+    at processImmediate (node:internal/timers:493:21)</pre><pre class="suite-consolelog-item-message">TEST ERROR: AppError: Cannot reset password for "test5@example.com", same as current password
+    at /root/code/KW_Workspace/knightwise/backend/routes/authRoutes.js:361:11 {
+  statusCode: 400,
+  userMessage: 'Your new password cannot be the same as your current password.'
+}</pre></div></div></details><details id="suite-4" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/test.test.js</div><div class="suite-time">2.768s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename"> </div><div class="test-title">GET /api/test/topic/:topicName</div><div class="test-status">passed</div><div class="test-duration">0.315s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename"> </div><div class="test-title">GET /api/test/topic/:topicName requires auth</div><div class="test-status">passed</div><div class="test-duration">0.16s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename"> </div><div class="test-title">GET /api/test/mocktest</div><div class="test-status">passed</div><div class="test-duration">1.238s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename"> </div><div class="test-title">GET /api/test/mocktest requires auth</div><div class="test-status">passed</div><div class="test-duration">0.13s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
     at Runtime._execModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1439:24)
     at Runtime._loadModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1022:12)
     at Runtime.requireModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:882:12)
@@ -805,4 +2112,29 @@ header {
     at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17) {
   statusCode: 401,
   userMessage: 'Unauthorized'
-}</pre></div></div></details></main></body></html>
+}</pre></div></div></details><details id="suite-5" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/graderTests/fillInTheBlanks.test.js</div><div class="suite-time">0.086s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Correct Answer Tests</div><div class="test-title">should return 1.0 for exact match</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Correct Answer Tests</div><div class="test-title">should accept any valid answer</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Correct Answer Tests</div><div class="test-title">should be case insensitive</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Correct Answer Tests</div><div class="test-title">should trim whitespace</div><div class="test-status">passed</div><div class="test-duration">0.004s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Incorrect/Fuzzy Answer Tests</div><div class="test-title">should return 0.0 for wrong answer</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Incorrect/Fuzzy Answer Tests</div><div class="test-title">should return partial credit for close answer</div><div class="test-status">passed</div><div class="test-duration">0.004s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Incorrect/Fuzzy Answer Tests</div><div class="test-title">should give lower score for worse close answer</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Incorrect/Fuzzy Answer Tests</div><div class="test-title">should display first acceptable answer in feedback</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Incorrect/Fuzzy Answer Tests</div><div class="test-title">should return 0.0 for empty input</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Fill-In-The-Blanks Grader &gt; Error Handling Tests</div><div class="test-title">should throw error if no acceptable answers exist</div><div class="test-status">passed</div><div class="test-duration">0.008s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
+    at Runtime._execModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1439:24)
+    at Runtime._loadModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1022:12)
+    at Runtime.requireModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:882:12)
+    at runTestInternal (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:296:33)
+    at runTest (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:444:34)</pre><pre class="suite-consolelog-item-message">Loaded environment file: .env.test</pre></div></div></details><details id="suite-6" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/graderTests/multipleChoice.test.js</div><div class="suite-time">0.109s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Multiple Choice Grader &gt; Correct Answer Tests</div><div class="test-title">should return 1.0 for correct answer</div><div class="test-status">passed</div><div class="test-duration">0.005s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Multiple Choice Grader &gt; Correct Answer Tests</div><div class="test-title">should be case insensitive</div><div class="test-status">passed</div><div class="test-duration">0.011s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Multiple Choice Grader &gt; Correct Answer Tests</div><div class="test-title">should trim whitespace</div><div class="test-status">passed</div><div class="test-duration">0.004s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Multiple Choice Grader &gt; Incorrect Answer Tests</div><div class="test-title">should return 0.0 for wrong answer</div><div class="test-status">passed</div><div class="test-duration">0.005s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Multiple Choice Grader &gt; Incorrect Answer Tests</div><div class="test-title">should provide correct answer in feedback</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Multiple Choice Grader &gt; Error Handling Tests</div><div class="test-title">should throw error if no correct answer exists</div><div class="test-status">passed</div><div class="test-duration">0.008s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
+    at Runtime._execModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1439:24)
+    at Runtime._loadModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1022:12)
+    at Runtime.requireModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:882:12)
+    at runTestInternal (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:296:33)
+    at runTest (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:444:34)</pre><pre class="suite-consolelog-item-message">Loaded environment file: .env.test</pre></div></div></details><details id="suite-7" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/graderTests/selectAllThatApply.test.js</div><div class="suite-time">0.059s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Select-All-That-Apply Grader &gt; Perfect Score Tests</div><div class="test-title">should return 1.0 for all correct selections</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Select-All-That-Apply Grader &gt; Perfect Score Tests</div><div class="test-title">should be case insensitive</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Select-All-That-Apply Grader &gt; Perfect Score Tests</div><div class="test-title">should trim whitespace</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Select-All-That-Apply Grader &gt; Partial Credit Tests</div><div class="test-title">should give 0.5 for selecting only one correct answer</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Select-All-That-Apply Grader &gt; Partial Credit Tests</div><div class="test-title">should penalize incorrect selections</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Select-All-That-Apply Grader &gt; Partial Credit Tests</div><div class="test-title">should handle mixed correct and incorrect</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Select-All-That-Apply Grader &gt; Zero Score Tests</div><div class="test-title">should return 0.0 for all incorrect selections</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Select-All-That-Apply Grader &gt; Zero Score Tests</div><div class="test-title">should return 0.0 for empty selection</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Select-All-That-Apply Grader &gt; Zero Score Tests</div><div class="test-title">should not return 1.0 when incorrect answers are included</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
+    at Runtime._execModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1439:24)
+    at Runtime._loadModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1022:12)
+    at Runtime.requireModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:882:12)
+    at runTestInternal (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:296:33)
+    at runTest (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:444:34)</pre><pre class="suite-consolelog-item-message">Loaded environment file: .env.test</pre></div></div></details><details id="suite-8" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/graderTests/dragAndDrop.test.js</div><div class="suite-time">0.096s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Drag and Drop Grader &gt; Perfect Placement Tests</div><div class="test-title">should return 1.0 for all correct placements</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Drag and Drop Grader &gt; Perfect Placement Tests</div><div class="test-title">should be case insensitive</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Drag and Drop Grader &gt; Perfect Placement Tests</div><div class="test-title">should trim whitespace</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Drag and Drop Grader &gt; Partial Credit Tests</div><div class="test-title">should give partial credit for some correct placements</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Drag and Drop Grader &gt; Partial Credit Tests</div><div class="test-title">should give partial credit for one correct placement</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Drag and Drop Grader &gt; Zero Score Tests</div><div class="test-title">should return 0.0 for all incorrect placements</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Drag and Drop Grader &gt; Empty User Placement Tests</div><div class="test-title">should return 0.0 when userPlacements is empty</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Drag and Drop Grader &gt; Empty User Placement Tests</div><div class="test-title">should return 0.0 when userPlacements is null/undefined</div><div class="test-status">passed</div><div class="test-duration"> </div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Drag and Drop Grader &gt; Error Handling Tests</div><div class="test-title">should throw error if no mappings provided</div><div class="test-status">passed</div><div class="test-duration">0.007s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
+    at Runtime._execModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1439:24)
+    at Runtime._loadModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1022:12)
+    at Runtime.requireModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:882:12)
+    at runTestInternal (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:296:33)
+    at runTest (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:444:34)</pre><pre class="suite-consolelog-item-message">Loaded environment file: .env.test</pre></div></div></details><details id="suite-9" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">/root/code/KW_Workspace/knightwise/backend/__test__/graderTests/rankedChoice.test.js</div><div class="suite-time">0.043s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Ranked Choice Grader &gt; Perfect Ranking Tests</div><div class="test-title">should return 1.0 for perfect ranking</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Ranked Choice Grader &gt; Perfect Ranking Tests</div><div class="test-title">should be case insensitive</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Ranked Choice Grader &gt; Perfect Ranking Tests</div><div class="test-title">should trim whitespace</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Ranked Choice Grader &gt; Partial Credit Tests</div><div class="test-title">should give partial credit for one swap</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Ranked Choice Grader &gt; Partial Credit Tests</div><div class="test-title">should give lower score for multiple swaps</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Ranked Choice Grader &gt; Zero Score Tests</div><div class="test-title">should return 0.0 for completely reversed ranking</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div></div><div class="suite-consolelog"><div class="suite-consolelog-header">Console Log</div><div class="suite-consolelog-item"><pre class="suite-consolelog-item-origin">    at Object.&lt;anonymous&gt; (/root/code/KW_Workspace/knightwise/backend/config/env.js:23:9)
+    at Runtime._execModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1439:24)
+    at Runtime._loadModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:1022:12)
+    at Runtime.requireModule (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runtime/build/index.js:882:12)
+    at runTestInternal (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:296:33)
+    at runTest (/root/code/KW_Workspace/knightwise/backend/node_modules/jest-runner/build/runTest.js:444:34)</pre><pre class="suite-consolelog-item-message">Loaded environment file: .env.test</pre></div></div></details></main></body></html>


### PR DESCRIPTION
This PR addresses [SCRUM-164: Add Run Functionality to /submitCode](https://knightwise.atlassian.net/browse/SCRUM-164).

- This PR modifies the programming question backend to implement a new "Test Run" feature:
  - This new feature allows users to execute their code against the first test case associated with a question.
  - The test run is not stored in the Response table like actual submissions. Instead, they are saved to a new TestRun database table, which just records the IDs of the user and question (foreign keys) and a timestamp.
    - These saved test run entries are used to enforce a maximum limit of test runs per problem per day, currently set to 3. The test run limit and global actual submission limit (currently 10) **ARE ISOLATED AND DO NOT AFFECT EACH OTHER**.
- The `/submitCode` endpoint now takes and returns a new parameter, `isTestRun`. If true, user code is executed and saved as a test run. If false, user code is executed, submitted, graded, and saved as a response.
- Additionally, the code controller logic was tweaked to count compilation/runtime errors toward actual submission/test run attempts, saving them to the database. Unit tests were added to verify this tweak.

- Unit tests were added to verify new functionality:
  - Existing tests in `code.test.js` were modified to use the new `isTestRun` parameter.
  - Further tests were added to verify intended test run behavior, new submission limits, and other edge cases.

- This PR includes the necessary database schema changes to support the new functionality:
  - New **TestRun** table with **USERID** (foreign key), **QUESTION_ID** (foreign key), and **DATETIME**.
  - KW_Testing was synced to these schema changes.

- This PR includes changes to the `swagger.yaml` documentation corresponding to the new changes.

- The changes were tested locally.

- Below: Proof of new test cases passing:
<img width="893" height="371" alt="image" src="https://github.com/user-attachments/assets/2e46ad6a-4f6e-4a9f-9c5b-f9ed33f9de0b" />
<img width="1704" height="885" alt="image" src="https://github.com/user-attachments/assets/b426e466-ba1d-4ccb-bccc-bfb972de2679" />

- Below: Example of new `isTestRun` parameter for an actual code submission. Looks like I exceeded 10 global submissions!
<img width="1276" height="722" alt="image" src="https://github.com/user-attachments/assets/ce5b7513-f59a-46fa-a1cb-e8c714247c67" />

- Below: Example of new `isTestRun` parameter for a test run. Note how this doesn't return grading info, just the stdout result of running against the first test case.
<img width="1265" height="874" alt="image" src="https://github.com/user-attachments/assets/c35a0d1b-b400-4b47-b367-2d0f1967170e" />

- Below: Proof of distinct test run limit. Looks like we hit 3 test runs for this question!
<img width="1272" height="725" alt="image" src="https://github.com/user-attachments/assets/032f6131-064e-4499-85b9-3b07970ca3a6" />

- Below: But we can still do 3 test runs for another question. The test run limit is per question, not global.
<img width="1270" height="885" alt="image" src="https://github.com/user-attachments/assets/dcc957fa-92c5-402e-8bce-9c6786ae2a17" />

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-164