### PR TITLE
SCRUM-191: Professor Draft Questions

### DIFF
--- a/backend/__test__/admin.test.js
+++ b/backend/__test__/admin.test.js
@@ -171,6 +171,7 @@ describe("Admin Routes", () => {
         points_possible: 1.0,
         question_text: 'alias',
         owner_id: null,
+        is_published: true,
         answer_text: ['a'],
         answer_correctness: [1],
         answer_rank: [1],
@@ -189,7 +190,7 @@ describe("Admin Routes", () => {
 
       // Expect Discord notification
       expect(notifyUserEvent).toHaveBeenCalledWith(
-        expect.stringContaining("New question created")
+        expect.stringContaining("New question published")
       );
     });
 
@@ -285,17 +286,17 @@ describe("Admin Routes", () => {
       expect(res.statusCode).toBe(401);
     });
 
-    test("DELETE /api/admin/problems/:id requires admin token", async () => {
+    test("DELETE /api/admin/problems/:id requires auth token", async () => {
       const res = await request(app).delete("/api/admin/problems/noauth");
       expect(res.statusCode).toBe(401);
     });
 
-    test("POST /api/admin/createquestion requires admin token", async () => {
+    test("POST /api/admin/createquestion requires auth token", async () => {
       const res = await request(app).post("/api/admin/createquestion");
       expect(res.statusCode).toBe(401);
     });
 
-    test("GET /api/admin/problems/:id requires admin token", async () => {
+    test("GET /api/admin/problems/:id requires auth token", async () => {
       const res = await request(app).get("/api/admin/problems/noauth");
       expect(res.statusCode).toBe(401);
     });

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -158,6 +158,7 @@ router.delete("/users/:id", adminMiddleware, asyncHandler(async (req, res) => {
   await req.db.query('DELETE FROM EmailCode WHERE EMAIL = ?', [user.EMAIL]);
   await req.db.query('DELETE FROM Response WHERE USERID = ?', [userId]);
   console.log(`User ${userId} and all associated data deleted successfully`);
+  notifyUserEvent(`Admin deleted user: ${user.USERNAME}`);
 
   return res
     .status(200)
@@ -205,6 +206,7 @@ router.delete("/problems/:id", adminOrProf, asyncHandler(async (req, res) => {
   await req.db.query('DELETE FROM AnswerText WHERE QUESTION_ID = ?', [questionId]);
   await req.db.query('DELETE FROM Response WHERE PROBLEM_ID = ?', [questionId]);
   console.log(`Question ${questionId} and all associated data deleted successfully`);
+  notifyUserEvent(`Question ${questionId} and all associated data deleted by ${req.user?.role} (owner ID: ${question.OWNER_ID})`);
 
   return res
     .status(200)

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -189,7 +189,13 @@ router.post("/sendotp", asyncHandler(async (req, res) => {
   // check if the email is already registered to avoid unregistered users from reset password
   if (purpose === "reset") 
   {
-    if (users.length === 0) 
+    // If a professor is trying to reset their password
+    const [profUsers] = await req.db.query(
+      'SELECT * FROM Professor WHERE EMAIL = ?',
+      [email]
+    );
+
+    if (users.length === 0 && profUsers.length === 0) 
     {
       throw new AppError(`Password reset failed, email not registered: ${email}`, 404, "User not found");
     }

--- a/backend/routes/problems.js
+++ b/backend/routes/problems.js
@@ -35,6 +35,7 @@ const getAnswersForQuestion = async (questionId, db) => {
 /**
  * @route   GET /api/problems/:id
  * @desc    Fetch a question by its ID with its associated answers
+ *          Only fetches published questions
  * @access  Protected
  * 
  * @param {import('express').Request}  req - Express request object
@@ -42,17 +43,17 @@ const getAnswersForQuestion = async (questionId, db) => {
  * @returns {Promise<void>} - JSON response with question and its answers
  */
 router.get('/:id', authMiddleware, asyncHandler(async (req, res) => {
-const { id } = req.params;
+  const { id } = req.params;
 
   // Find question by ID
   const [questions] = await req.db.query(
-    'SELECT * FROM Question WHERE ID = ?',
+    'SELECT * FROM Question WHERE ID = ? AND IS_PUBLISHED = 1',
     [id]
   );
 
   if (questions.length === 0) 
   {
-    throw new AppError(`No questions associated with ID: ${id}`, 404, "Question not found");
+    throw new AppError(`No published questions associated with ID: ${id}`, 404, "Question not found");
   }
 
   const question = questions[0];

--- a/backend/routes/testRoutes.js
+++ b/backend/routes/testRoutes.js
@@ -47,25 +47,25 @@ const pairAnswersWithQuestions = async (questions, db) => {
 
 /**
  * @route   GET /api/test/topic/:topicName
- * @desc    Fetch questions for a given subcategory (e.g. Backtracking)
+ * @desc    Fetch published questions for a given subcategory (e.g. Backtracking)
  * @access  Protected
  * 
  * @param {import('express').Request}  req - Express request object
  * @param {import('express').Response} res - Express response object
- * @returns {Promise<void>} - JSON response with the subcategory's questions and answers
+ * @returns {Promise<void>} - JSON response with the subcategory's published questions and answers
  */
 router.get("/topic/:topicName", authMiddleware, asyncHandler(async (req, res) => {
   const { topicName } = req.params;
 
   // Get all questions of this subcategory
   const [questions] = await req.db.query(
-    'SELECT * FROM Question WHERE SUBCATEGORY = ?',
+    'SELECT * FROM Question WHERE SUBCATEGORY = ? AND IS_PUBLISHED = 1',
     [topicName]
   );
 
   if (!questions || questions.length === 0) 
   {
-    throw new AppError(`No questions exist for subcategory: ${topicName}`, 404, "Question not found");
+    throw new AppError(`No published questions exist for subcategory: ${topicName}`, 404, "Question not found");
   }
 
   const questionsWithAnswers = await pairAnswersWithQuestions(questions, req.db);
@@ -85,16 +85,16 @@ router.get("/mocktest", authMiddleware, asyncHandler(async (req, res) => {
   const sections = ["A", "B", "C", "D"];
   const questionsBySection = {};
 
-  // shuffled problem per section and pick three question randomly
+  // shuffled problem per section and pick three published questions randomly
   for (const section of sections) {
     const [questions] = await req.db.query(
-      'SELECT * FROM Question WHERE SECTION = ?',
+      'SELECT * FROM Question WHERE SECTION = ? AND IS_PUBLISHED = 1',
       [section]
     );
 
     if (!questions || questions.length === 0) 
     {
-      throw new AppError(`Question not found in section: ${section}`, 404, "Question not found");
+      throw new AppError(`Published question not found in section: ${section}`, 404, "Question not found");
     }
     const shuffled = questions.sort(() => 0.5 - Math.random());
     questionsBySection[section] = shuffled.slice(0, 3);

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -131,7 +131,7 @@ paths:
       - Authentication
       summary: Send user one-time password.
       operationId: sendOtp
-      description: Sends a one-time password to the user's email for account verification during signup.
+      description: Sends a one-time password to the email for account verification. Used for both user and professor signup and password reset flows.
       consumes:
       - application/json
       produces:
@@ -295,17 +295,6 @@ paths:
       summary: Create a question.
       operationId: createQuestion
       description: Creates a new question and its associated answer objects. Accessible by admin key or verified professor JWT. Professors can only submit questions under their own owner ID regardless of what is passed in.
-  
-  /code/submitCode:
-    post:
-      tags:
-      - Problems
-      summary: Submit or test code against a programming question.
-      operationId: submitCode
-      description: |
-        Submits code to Judge0 for execution. Supports two modes:
-        - **Graded Submission** (`isTestRun: false`): Runs code against all test cases, grades the result, and records the response. Counts toward the daily submission limit (10/day).
-        - **Test Run** (`isTestRun: true`): Runs code against only the first test case and returns raw output without grading or saving a response. Limited to 3 runs per problem per day.
       security:
         - BearerAuth: []
       consumes:
@@ -357,12 +346,46 @@ paths:
           description: Question Not Found
         500:
           description: Server Error
+    put:
+      tags:
+      - Admins
+      - Professors
+      summary: Edit question by ID.
+      operationId: editQuestion
+      description: Replaces a question's content and all associated answers entirely. Auto-unpublishes the question if it was published. Professors can only edit their own questions. Admins can edit any question.
+      security:
+        - BearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: integer
+        description: The unique ID of the question.
+      - in: body
+        name: questionItem
+        description: Replacement question and answer details.
+        schema:
+          $ref: '#/definitions/EditQuestion'
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden
+        404:
+          description: Question Not Found
+        500:
+          description: Server Error
     delete:
       tags:
       - Admins
+      - Professors
       summary: Delete question by ID.
       operationId: deleteQuestion
-      description: Deletes a question and all associated answers and responses. Admin only.
+      description: Deletes a question and all associated answers and responses. Professors can only delete their own questions. Admins can delete any question.
       security:
         - BearerAuth: []
       parameters:
@@ -376,8 +399,58 @@ paths:
           description: OK
         401:
           description: Unauthorized
+        403:
+          description: Forbidden
         404:
           description: Question Not Found
+        500:
+          description: Server Error
+
+  /admin/problems/{id}/publish:
+    post:
+      tags:
+      - Admins
+      - Professors
+      summary: Publish a draft question.
+      operationId: publishQuestion
+      description: Sets a draft question's IS_PUBLISHED flag to true, making it visible in topic practice and mock tests. Professors can only publish their own questions. Admins can publish any question.
+      security:
+        - BearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: integer
+        description: The unique ID of the question.
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Question already published
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden
+        404:
+          description: Question Not Found
+        500:
+          description: Server Error
+
+  /admin/drafts:
+    get:
+      tags:
+      - Admins
+      - Professors
+      summary: Fetch draft question metadata.
+      operationId: getDrafts
+      description: Returns metadata for all unpublished questions. Professors see only their own drafts. Admins see all drafts.
+      security:
+        - BearerAuth: []
+      responses:
+        200:
+          description: OK
+        401:
+          description: Unauthorized
         500:
           description: Server Error
 
@@ -428,13 +501,6 @@ paths:
       responses:
         201:
           description: Created
-        name: submitCodeItem
-        description: Code submission details.
-        schema:
-          $ref: '#/definitions/SubmitCode'
-      responses:
-        200:
-          description: OK
         400:
           description: Bad Request
         401:
@@ -515,6 +581,36 @@ paths:
           description: Professor Not Found
         500:
           description: Server Error
+
+  /code/submitCode:
+    post:
+      tags:
+      - Problems
+      summary: Submit or test code against a programming question.
+      operationId: submitCode
+      description: |
+        Submits code to Judge0 for execution. Supports two modes:
+        - **Graded Submission** (`isTestRun: false`): Runs code against all test cases, grades the result, and records the response. Counts toward the daily submission limit (10/day).
+        - **Test Run** (`isTestRun: true`): Runs code against only the first test case and returns raw output without grading or saving a response. Limited to 3 runs per problem per day.
+      security:
+        - BearerAuth: []
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: submitCodeItem
+        description: Code submission details.
+        schema:
+          $ref: '#/definitions/SubmitCode'
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request
+        401:
+          description: Unauthorized
         404:
           description: Question or Test Cases Not Found
         429:
@@ -523,14 +619,14 @@ paths:
           description: Server Error
         502:
           description: Judge0 Service Unavailable
-  
+
   /test/topic/{topicName}:
     get:
       tags:
       - Problems
       summary: Fetch questions for a specific topic.
       operationId: getTopicQuestions
-      description: Retrieves all questions for a given subcategory (e.g., Backtracking, Recursion).
+      description: Retrieves all published questions for a given subcategory (e.g., Backtracking, Recursion).
       security:
         - BearerAuth: []
       parameters:
@@ -555,7 +651,7 @@ paths:
       - Problems
       summary: Generate a mock test.
       operationId: getMockTest
-      description: Retrieves a randomly generated mock test with questions from all sections (A, B, C, D).
+      description: Retrieves a randomly generated mock test with published questions from all sections (A, B, C, D).
       security:
         - BearerAuth: []
       responses:
@@ -608,7 +704,7 @@ paths:
       - Problems
       summary: Fetch problem by its ID.
       operationId: getProblemById
-      description: Retrieves a practice problem by its ID.
+      description: Retrieves a published practice problem by its ID.
       parameters:
       - name: id
         in: path
@@ -775,6 +871,7 @@ definitions:
     - subcategory
     - points_possible
     - question_text
+    - is_published
     - answer_text
     - answer_correctness
     - answer_rank
@@ -805,6 +902,10 @@ definitions:
         type: integer
         example: null
         description: Owner professor ID. Ignored for professor requests — always forced to the requesting professor's own ID.
+      is_published:
+        type: boolean
+        example: false
+        description: Whether to publish immediately or save as draft. Required.
       answer_text:
         type: array
         items:
@@ -828,7 +929,67 @@ definitions:
           type: string
         example: ["a", "b", "c", "d"]
         description: Correct placement field for each of answer_text options. Only used in Drag and Drop questions.
-        
+
+  EditQuestion:
+    type: object
+    required:
+    - type
+    - author_exam_id
+    - section
+    - category
+    - subcategory
+    - points_possible
+    - question_text
+    - answer_text
+    - answer_correctness
+    - answer_rank
+    - answer_placement
+    properties:
+      type:
+        type: string
+        example: "Multiple Choice"
+      author_exam_id:
+        type: string
+        example: "KnightWise"
+      section:
+        type: string
+        example: "DSN"
+      category:
+        type: string
+        example: "Programming"
+      subcategory:
+        type: string
+        example: "Python"
+      points_possible:
+        type: number
+        example: 5.0
+      question_text:
+        type: string
+        example: "What is Python's print function?"
+      answer_text:
+        type: array
+        items:
+          type: string
+        example: ["print", "printf", "println", "put"]
+      answer_correctness:
+        type: array
+        items:
+          type: integer
+        example: [1, 0, 0, 0]
+        description: Which answer_text is considered a correct answer.
+      answer_rank:
+        type: array
+        items:
+          type: integer
+        example: [1, 2, 3, 4]
+        description: Correct ranking of answer_text options. Only used in Ranked Choice questions.
+      answer_placement:
+        type: array
+        items:
+          type: string
+        example: ["a", "b", "c", "d"]
+        description: Correct placement field for each of answer_text options. Only used in Drag and Drop questions.
+
   SubmitCode:
     type: object
     required:


### PR DESCRIPTION
This PR addresses [SCRUM-191: Implement Professor Draft Questions](https://knightwise.atlassian.net/browse/SCRUM-191).

- This PR adds backend support for professor accounts to create and publish draft questions.
  - New admin endpoints have been added for draft question support, which are accessible to professors.
  - For most of the added functionalities, admins can utilize the endpoint for any question, while professors can only utilize the endpoint for questions they own.
  - The following endpoints were added:
    - **GET /api/admin/drafts**: Get metadata for all draft questions (ID, TYPE, QUESTION_TEXT, etc.).
      - Metadata doesn't include associated answers. Those can be fetched by professors using ** GET/api/admin/problems/:id**.
    - **PUT /api/admin/problems/:id**: Overwrites question and answer content, used for editing draft questions.
    - **POST /api/admin/problems/:id/publish**: Publish a draft question, making it visible in topic practice/mock tests.
    - Modified **DELETE /api/admin/problems/:id** to be usable to professors (professors can delete their own questions).
    - Modified **POST /api/admin/createquestion** so that questions must be created with an is_published status (true to publish on creation, false to create as draft).
  - Unit tests were added to verify new functionality.
  - `swagger.yaml` documentation was updated.

- Miscellaneous changes were made, like adding Discord webhook notifications for admin user deletion and admin/professor question deletion.

- Changes were tested locally.

- Below: Proof of all new unit tests passing.
<img width="877" height="371" alt="image" src="https://github.com/user-attachments/assets/8a2a3e2b-7e55-4ff2-83d3-47c5282c14b2" />


**End-to-End Test Flow:**

- Below: A professor logs in to their account.
<img width="1726" height="945" alt="image" src="https://github.com/user-attachments/assets/d919cea5-2ba7-401f-adc8-8eaa547cb578" />

- Below: A professor creates a draft question. 
- Note that `is_published` is false.
<img width="1706" height="938" alt="image" src="https://github.com/user-attachments/assets/300b51f1-0685-4c3f-8b74-01a627036e49" />

- Below: A Discord webhook notification is sent. 
- A different message is sent depending on whether the professor creates the question in draft state or published state.
<img width="739" height="105" alt="image" src="https://github.com/user-attachments/assets/04289408-96bd-4436-9b8b-605e2791dd61" />

- Below: A professor can fetch all draft questions that they own. Only one in this case.
<img width="1714" height="725" alt="image" src="https://github.com/user-attachments/assets/42e231f6-accd-4d43-bd21-27f007a0e569" />

- Below: Since question is draft, it can't be found by **GET /api/test/topic** or **GET /api/problems/:id**
<img width="1715" height="454" alt="image" src="https://github.com/user-attachments/assets/da85de54-d8df-472d-acc7-afd9b6437d8c" />
<img width="1706" height="471" alt="image" src="https://github.com/user-attachments/assets/9ef07666-b957-4d9f-9c53-2d3d29520b6e" />

- Below: But it does show up in the admin version of GET problem by ID!
- Note that it shows associated answers unlike the GET drafts endpoint, which just shows metadata.
<img width="1720" height="958" alt="image" src="https://github.com/user-attachments/assets/b3d6cd2e-b047-469b-8f25-827cf7da176f" />

- Below: Professor can use the PUT endpoint to modify question contents.
- Note that this doesn't take an "is_published" field since, regardless of whether the question was published or draft, editing a question puts it back in draft state.
<img width="1717" height="853" alt="image" src="https://github.com/user-attachments/assets/a07934c5-a12b-487c-a8c4-39cd940080cd" />

- Below: Proof that question has been indeed edited.
<img width="1703" height="922" alt="image" src="https://github.com/user-attachments/assets/0e7f4aea-8029-4c8c-bb87-8e50e6708f2e" />

- Below: Professor publishes the question.
<img width="1709" height="587" alt="image" src="https://github.com/user-attachments/assets/e1bf7b56-8500-4b2d-9459-01b6641e8912" />

- Below: Discord webhook notification sent when question is published.
<img width="658" height="85" alt="image" src="https://github.com/user-attachments/assets/5e4ddcef-bc76-4786-846a-212e03405d29" />

- Below: Drafts are now empty.
<img width="1721" height="559" alt="image" src="https://github.com/user-attachments/assets/e68181e4-2e8e-4de9-9474-9f08594dc916" />

- Below: Now published, the question can be found in GET by topic and GET by id. Question can now be used in topic practice and mock tests.
<img width="1719" height="934" alt="image" src="https://github.com/user-attachments/assets/4ed67471-e3fb-48cc-a988-0226e8ed91c8" />
<img width="1713" height="942" alt="image" src="https://github.com/user-attachments/assets/cb3baaf8-91af-4570-b437-65b65ec5a5cf" />

- Below: Can't publish a question if it's already published.
<img width="1721" height="588" alt="image" src="https://github.com/user-attachments/assets/776d81a4-477f-40f3-b372-a471ed53bed6" />

- Below: Let's update the published question.
<img width="1729" height="915" alt="image" src="https://github.com/user-attachments/assets/e93b9d99-8f54-47c7-88be-2879aa1661c4" />

- Below: Discord webhook notification sent (the bottom one).
<img width="851" height="152" alt="image" src="https://github.com/user-attachments/assets/7f35f80b-453b-420d-8fbc-08cedbaa1451" />

- Below: Yep, it's back in drafts. Can't be found by regular GET by topic or by ID.
<img width="1708" height="709" alt="image" src="https://github.com/user-attachments/assets/3aa476ed-2e04-4af7-89b8-cfb0d798aad5" />
<img width="1706" height="441" alt="image" src="https://github.com/user-attachments/assets/471a63a4-2bf8-4097-8e5e-b87840e09657" />
<img width="1709" height="440" alt="image" src="https://github.com/user-attachments/assets/ed1c6656-2564-42fc-8ffb-08a41a2b21ef" />

- Below: This professor can't edit a question that doesn't belong to them.
<img width="1712" height="885" alt="image" src="https://github.com/user-attachments/assets/9d020997-246f-41a4-a348-5ae52bf23ae2" />

- Below: Professor can't publish a draft that isn't theirs either.
- Note: This question in particular (68) was already published but you get the idea. They can't even access the endpoint.
<img width="1711" height="666" alt="image" src="https://github.com/user-attachments/assets/76c31f87-a72d-4cce-af87-2ebddcd53241" />

- Below: Professor can't delete a question that isn't theirs.
<img width="1720" height="642" alt="image" src="https://github.com/user-attachments/assets/1adce3fe-028b-4e0d-ab19-0515bd5db50c" />

- Below: But a professor _can_ delete their own question!
<img width="1719" height="649" alt="image" src="https://github.com/user-attachments/assets/a7f85936-7e4f-4e89-a358-80f4689fbd9f" />
<img width="1721" height="673" alt="image" src="https://github.com/user-attachments/assets/ef42d710-a311-41f5-bae0-53f3b47be4c0" />


**Other supporting screenshots:**

- Below: The new deletion notifications. Owner id is undefined/null because I forgot to pass one in during question creation.
<img width="836" height="139" alt="image" src="https://github.com/user-attachments/assets/9050a261-bbeb-47d0-8ebf-2c67e17e9938" />

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-191