### PR TITLE
SCRUM-199: Create /api/admin/published

### DIFF
--- a/backend/__test__/admin.test.js
+++ b/backend/__test__/admin.test.js
@@ -315,9 +315,9 @@ describe("Admin Routes", () => {
 
     test("GET /api/admin/published returns all published questions for admin", async () => { 
       // Insert 3 questions, two published and one draft
-      await insertQuestion("MCQ", [], true);
-      await insertQuestion("MCQ", [], false);
-      await insertQuestion("MCQ", [], true);
+      await insertQuestion("MCQ", [], { isPublished: true });
+      await insertQuestion("MCQ", [], { isPublished: false });
+      await insertQuestion("MCQ", [], { isPublished: true });
 
       // Call endpoint as admin
       const res = await request(app)

--- a/backend/__test__/admin.test.js
+++ b/backend/__test__/admin.test.js
@@ -18,7 +18,7 @@
 const request = require("supertest");
 const jwt = require("jsonwebtoken");
 const { app, pool } = require("../server");
-const { TEST_USER, verifyTestDatabase } = require("./testHelpers");
+const { TEST_USER, verifyTestDatabase, insertQuestion } = require("./testHelpers");
 
 // Mock Mailjet
 const Mailjet = require('node-mailjet');
@@ -311,4 +311,19 @@ describe("Admin Routes", () => {
       expect(res.statusCode).toBe(401);
     });
 
+    test("published - returns all published questions for admin", async () => { 
+      // Insert 3 questions, two published and one draft
+      await insertQuestion("MCQ", [], true);
+      await insertQuestion("MCQ", [], false);
+      await insertQuestion("MCQ", [], true);
+
+      // Call endpoint as admin
+      const res = await request(app)
+        .get("/api/admin/published")
+        .set("Authorization", `Bearer ${process.env.ADMIN_KEY}`);
+
+      // Admin should be able to see both published questions
+      expect(res.statusCode).toBe(200);
+      expect(res.body.published.length).toBeGreaterThanOrEqual(2);
+    });
 })

--- a/backend/__test__/prof.test.js
+++ b/backend/__test__/prof.test.js
@@ -830,8 +830,8 @@ describe("Admin Routes - Draft/Publish", () => {
     const { profId: otherId } = await insertProf(pool, "otherpubprof", "otherpub@ucf.edu", 1);
 
     // Insert published questions for both professors
-    await insertQuestion("MCQ", [], true, profId);
-    await insertQuestion("MCQ", [], true, otherId);
+    await insertQuestion("MCQ", [], { isPublished: true, ownerId: profId });
+    await insertQuestion("MCQ", [], { isPublished: true, ownerId: otherId });
 
     // First professor calls endpoint
     const res = await request(app)

--- a/backend/__test__/prof.test.js
+++ b/backend/__test__/prof.test.js
@@ -19,7 +19,7 @@ const request = require('supertest');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const { app, pool } = require('../server');
-const { verifyTestDatabase } = require('./testHelpers');
+const { verifyTestDatabase, insertQuestion } = require('./testHelpers');
 
 // Mock Discord webhook
 const { notifyUserEvent } = require('../services/discordWebhook');
@@ -822,5 +822,56 @@ describe("Admin Routes - Draft/Publish", () => {
       .set("Authorization", `Bearer ${attackerToken}`);
 
     expect(res.statusCode).toBe(403);
+  });
+
+  test("published - professor sees only their own published questions", async () => {
+    // Create two professors
+    const { profId, token } = await insertProf(pool, "pubviewprof", "pubview@ucf.edu", 1);
+    const { profId: otherId } = await insertProf(pool, "otherpubprof", "otherpub@ucf.edu", 1);
+
+    // Insert published questions for both professors
+    await insertQuestion("MCQ", [], true, profId);
+    await insertQuestion("MCQ", [], true, otherId);
+
+    // First professor calls endpoint
+    const res = await request(app)
+      .get("/api/admin/published")
+      .set("Authorization", `Bearer ${token}`);
+
+    // Should only see first prof's question
+    expect(res.statusCode).toBe(200);
+    expect(res.body.published.length).toBe(1);
+    expect(res.body.published[0].OWNER_ID).toBe(profId);
+  });
+
+  test("published - draft questions do not appear in published", async () => {
+    const { profId, token } = await insertProf(pool, "draftcheckprof", "draftcheck@ucf.edu", 1);
+
+    // Insert draft queston for the professor
+    await insertQuestion("MCQ", [], false, profId);
+
+    const res = await request(app)
+      .get("/api/admin/published")
+      .set("Authorization", `Bearer ${token}`);
+
+    // Shouldn't see it
+    expect(res.statusCode).toBe(200);
+    expect(res.body.published.length).toBe(0);
+  });
+
+  test("published - returns empty array when professor has no published questions", async () => {
+    const { token } = await insertProf(pool, "emptypubprof", "emptypub@ucf.edu", 1);
+
+    const res = await request(app)
+      .get("/api/admin/published")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.published).toEqual([]);
+  });
+
+  test("published - requires auth token", async () => {
+    const res = await request(app).get("/api/admin/published");
+    expect(res.statusCode).toBe(401);
   });
 });

--- a/backend/__test__/test.test.js
+++ b/backend/__test__/test.test.js
@@ -466,7 +466,8 @@ describe("POST /api/test/submit", () => {
       [
         { text: 'Right', isCorrect: true  },
         { text: 'Wrong', isCorrect: false },
-      ], pointValue);
+      ], 
+      { points: pointValue });
 
       // First submit should only award 50 exp, not 20 points' worth (higher than 50 exp)
       await submitAndFetch(questionId, 'Right', token);

--- a/backend/__test__/testHelpers.js
+++ b/backend/__test__/testHelpers.js
@@ -60,7 +60,7 @@ const insertPurchase = async (userId, itemInfo = {}, isEquipped = false) => {
  * @param {number=null}   ownerId     - Question.OWNER_ID to insert. Null by default.
  * @returns {Promise<number>}           Inserted question ID
  */
-const insertQuestion = async (type, answers = [], points = 2.00, isPublished = true, ownerId = null) => {
+const insertQuestion = async (type, answers = [], { points = 2.00, isPublished = true, ownerId = null } = {}) => {
   const [result] = await pool.query(
     'INSERT INTO Question (QUESTION_TEXT, TYPE, SUBCATEGORY, SECTION, CATEGORY, POINTS_POSSIBLE, IS_PUBLISHED, OWNER_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
     ['Test question', type, 'Test Topic', 'A', 'Test Category', points, isPublished ? 1 : 0, ownerId]

--- a/backend/__test__/testHelpers.js
+++ b/backend/__test__/testHelpers.js
@@ -31,12 +31,14 @@ const TEST_USER = {
  * Inserts a question and its answers, returns question ID.
  * @param {string}         type     - Question.TYPE (e.g. 'Multiple Choice')
  * @param {Array<Object>}  answers  - Array of { text, isCorrect, rank, placement }
+ * @param {boolean=true} isPublished - True inserts as published, false inserts as draft. True by default.
+ * @param {number=null}     ownerId - Question.OWNER_ID to insert. Null by default.
  * @returns {Promise<number>} Inserted question ID
  */
-const insertQuestion = async (type, answers = []) => {
+const insertQuestion = async (type, answers = [], isPublished = true, ownerId = null) => {
   const [result] = await pool.query(
-    'INSERT INTO Question (QUESTION_TEXT, TYPE, SUBCATEGORY, SECTION, CATEGORY, POINTS_POSSIBLE) VALUES (?, ?, ?, ?, ?, ?)',
-    ['Test question', type, 'Test Topic', 'A', 'Test Category', 2.00]
+    'INSERT INTO Question (QUESTION_TEXT, TYPE, SUBCATEGORY, SECTION, CATEGORY, POINTS_POSSIBLE, IS_PUBLISHED, OWNER_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ['Test question', type, 'Test Topic', 'A', 'Test Category', 2.00, isPublished ? 1 : 0, ownerId]
   );
   const questionId = result.insertId;
 

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -57,6 +57,47 @@ const adminOrProf = [
 ];
 
 /**
+ * Helper function, gets questions for a given draft/published state
+ * Used in GET /api/admin/drafts and GET /api/admin/published
+ * @param {{ id: number, role: string }} user - User requesting questions (professor or admin)
+ * @param {boolean} isPublished - True to get published questions, false to get drafts
+ * @param {Object}  db          - Database connection pool
+ * @returns {Promise<Array>}    - Array of questions
+ */
+const getQuestionsByStatus = async (user, isPublished, db) => {
+  // Professors only see their own questions, admins see all
+  const [questions] = (user?.role === 'professor')
+    ? await db.query(
+        `SELECT
+          ID,
+          TYPE,
+          SECTION,
+          CATEGORY,
+          SUBCATEGORY,
+          POINTS_POSSIBLE,
+          QUESTION_TEXT,
+          OWNER_ID
+        FROM Question WHERE IS_PUBLISHED = ? AND OWNER_ID = ?`,
+        [isPublished ? 1 : 0, user.id]
+      )
+    : await db.query(
+        `SELECT
+          ID,
+          TYPE,
+          SECTION,
+          CATEGORY,
+          SUBCATEGORY,
+          POINTS_POSSIBLE,
+          QUESTION_TEXT,
+          OWNER_ID
+        FROM Question WHERE IS_PUBLISHED = ?`,
+        [isPublished ? 1 : 0]
+      );
+
+  return questions;
+}
+
+/**
  * Helper function, gets answers for a given question
  * @param {number} questionId - Question ID
  * @param {Object} db         - Database connection pool
@@ -480,36 +521,26 @@ router.post('/verifyprof/:id', adminMiddleware, asyncHandler(async (req, res) =>
  * @returns {Promise<void>} - JSON response with draft question metadata
  */
 router.get('/drafts', adminOrProf, asyncHandler(async (req, res) => {
-
-  // Professors only see their own drafts, admins see all
-  const [drafts] = (req.user?.role === 'professor')
-    ? await req.db.query(
-        `SELECT
-          ID,
-          TYPE,
-          SECTION,
-          CATEGORY,
-          SUBCATEGORY,
-          POINTS_POSSIBLE,
-          QUESTION_TEXT,
-          OWNER_ID
-        FROM Question WHERE IS_PUBLISHED = 0 AND OWNER_ID = ?`,
-        [req.user.id]
-      )
-    : await req.db.query(
-        `SELECT
-          ID,
-          TYPE,
-          SECTION,
-          CATEGORY,
-          SUBCATEGORY,
-          POINTS_POSSIBLE,
-          QUESTION_TEXT,
-          OWNER_ID
-        FROM Question WHERE IS_PUBLISHED = 0`
-      );
-
+  // Get draft questions
+  const drafts = await getQuestionsByStatus(req.user, false, req.db);
   res.json({ drafts });
+}));
+
+/**
+ * @route   GET /api/admin/published
+ * @desc    Get metadata for all published questions
+ *          Professors can only see their own published questions
+ *          Admins see all published questions.
+ * @access  Admin, Professor
+ * 
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>} - JSON response with published question metadata
+ */
+router.get('/published', adminOrProf, asyncHandler(async (req, res) => {
+  // Get published questions
+  const published = await getQuestionsByStatus(req.user, true, req.db);
+  res.json({ published });
 }));
 
 /**

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -458,8 +458,26 @@ paths:
       - Admins
       - Professors
       summary: Fetch draft question metadata.
-      operationId: getDrafts
+      operationId: getQuestionsByStatus
       description: Returns metadata for all unpublished questions. Professors see only their own drafts. Admins see all drafts.
+      security:
+        - BearerAuth: []
+      responses:
+        200:
+          description: OK
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+
+  /admin/published:
+    get:
+      tags:
+      - Admins
+      - Professors
+      summary: Fetch published question metadata.
+      operationId: getQuestionsByStatus
+      description: Returns metadata for all published questions. Professors see only their own published questions. Admins see all published questions.
       security:
         - BearerAuth: []
       responses:

--- a/frontend/src/pages/ProfessorDraftsPage.tsx
+++ b/frontend/src/pages/ProfessorDraftsPage.tsx
@@ -467,57 +467,24 @@ const ProfessorDraftsPage: React.FC = () => {
       setPublishedLoadError("");
 
       try {
-        const userDataRaw = localStorage.getItem("user_data");
-        const parsedUser = userDataRaw ? JSON.parse(userDataRaw) as { id?: number; ID?: number; firstName?: string; lastName?: string; name?: string } : {};
-        const parsedUserIdValue = (parsedUser.id ?? parsedUser.ID) as unknown;
-        const parsedUserId = Number(parsedUserIdValue);
-        const userId = Number.isFinite(parsedUserId) ? parsedUserId : null;
+        // Get published raw questions
+        const res = await api.get<{published: RawQuestion[] }>("/api/admin/published");
+        const questions = Array.isArray(res.data?.published) ? res.data.published : [];
 
-        const allSubcategories = Array.from(
-          new Set(availableSubcategories.length > 0 ? availableSubcategories : defaultSubcategories)
-        );
-        const results = await Promise.allSettled(
-          allSubcategories.map((subcategory) =>
-            api.get<RawQuestion[]>(`/api/test/topic/${encodeURIComponent(subcategory)}`)
-          )
-        );
-
-        const mergedQuestions: RawQuestion[] = [];
-        results.forEach((result) => {
-          if (result.status === "fulfilled" && Array.isArray(result.value.data)) {
-            mergedQuestions.push(...result.value.data);
-          }
-        });
-
-        const dedupedById = new Map<number, RawQuestion>();
-        mergedQuestions.forEach((question) => {
-          if (typeof question.ID === "number") {
-            dedupedById.set(question.ID, question);
-          }
-        });
-
-        const toPublishedQuestion = (question: RawQuestion): PublishedQuestion => ({
-          id: question.ID,
-          section: question.SECTION,
-          category: question.CATEGORY,
-          subcategory: question.SUBCATEGORY,
-          questionType: question.TYPE,
-          authorExamId: question.AUTHOR_EXAM_ID,
-          ownerId: question.OWNER_ID,
-        });
-
-        const ownerMatches = (question: RawQuestion) => {
-          if (userId === null) return true;
-          const questionOwnerId = Number(question.OWNER_ID);
-          return Number.isFinite(questionOwnerId) && questionOwnerId === userId;
-        };
-
-        const filtered = Array.from(dedupedById.values())
-          .filter(ownerMatches)
-          .map(toPublishedQuestion)
+        // Map to published question type and sort
+        const mapped = questions
+          .map((question): PublishedQuestion => ({
+            id: question.ID,
+            section: question.SECTION,
+            category: question.CATEGORY,
+            subcategory: question.SUBCATEGORY,
+            questionType: question.TYPE,
+            authorExamId: question.AUTHOR_EXAM_ID,
+            ownerId: question.OWNER_ID,
+          }))
           .sort((first, second) => second.id - first.id);
 
-        setPublishedQuestions(filtered);
+        setPublishedQuestions(mapped);
       } catch {
         setPublishedLoadError("Failed to load published questions.");
         setPublishedQuestions([]);
@@ -527,7 +494,7 @@ const ProfessorDraftsPage: React.FC = () => {
     };
 
     fetchPublishedQuestions();
-  }, [activeTab, isProfessor, availableSubcategories]);
+  }, [activeTab, isProfessor]);
 
   useLayoutEffect(() => {
     if (form.questionType !== "Ranked Choice") {


### PR DESCRIPTION
This PR addresses [SCRUM-199: Create /api/admin/published](https://knightwise.atlassian.net/browse/SCRUM-199).

- This PR adds full stack support for a new admin/professor endpoint, **GET** `/api/admin/published`.

- Backend support:
  - New endpoint **GET** `/api/admin/published`:
    - This is a sister endpoint of **GET** `/api/admin/drafts`, and gets published questions from the database.
    - If called by an admin, fetches _all_ published questions.
    - If called by a professor, fetches _that professor's_ published questions.
  - Both published and draft endpoints are now wrappers of a new helper function, `getQuestionsByStatus()`.
  - `testHelpers.js`:
    - Modified `insertQuestion()` to accept two new optional parameters:
      - boolean `isPublished`: True inserts question as published, false inserts as draft. True by default.
      - number `ownerId`: Used to set Question.OWNER_ID of question to insert. Null by default.
      - The 'points', 'isPublished' and 'ownerId' field are now part of an options object to avoid positional argument problems.
    - These new parameters improve test-ability (now we can test that professors can't see published questions of other professors). 

- Frontend support:
  - `ProfessorDraftsPage.tsx`:
    - Instead of iterating through all topics and filtering for published/validating owner, `fetchPublishedQuestions()` now simply calls the new endpoint.

- Integration tests have been added to `admin.test.js` and `prof.test.js` to verify proper functionality.
- `swagger.yaml` documentation has been updated to reflect the changes.
- Changes were tested locally.

- Below: Proof of all test cases passing.
<img width="879" height="376" alt="image" src="https://github.com/user-attachments/assets/e25c49d0-cf43-43e5-8e3c-c97012e25352" />

**End-to-End Test**
- Below: A logged-in professor creates a new draft question. The draft does not appear in Published Questions.
<img width="1912" height="939" alt="image" src="https://github.com/user-attachments/assets/64e3d0d7-c20b-42bb-9e86-a839bb719916" />
<img width="1903" height="934" alt="image" src="https://github.com/user-attachments/assets/9a04da9c-54c9-432b-8c4d-5e5836627908" />

- Below: Professor publishes the question. Now it does show up in the Published Questions section.
<img width="1907" height="924" alt="image" src="https://github.com/user-attachments/assets/b781a3fe-1d67-4532-af78-a3625d066607" />
<img width="1917" height="937" alt="image" src="https://github.com/user-attachments/assets/9ef1aabf-2270-4b6c-a0b6-95c3154fdd60" />

- Below: Professor edited the draft. This automatically un-publishes it, so it no longer appears in Published Questions.
<img width="1901" height="932" alt="image" src="https://github.com/user-attachments/assets/fc163ccc-3d65-40d0-a94f-8b3289216910" />

- Below: Professor creates another draft question and publishes both draft questions. They now both appear in Published Questions.
<img width="1919" height="942" alt="image" src="https://github.com/user-attachments/assets/88ab7895-2669-4877-be3d-4e34764fdd5e" />
<img width="1919" height="940" alt="image" src="https://github.com/user-attachments/assets/f17acb8c-b8f7-4062-a17c-8866c2047d9d" />

- Below: Proof that the new endpoint is being called, no iteration required.
<img width="1919" height="933" alt="image" src="https://github.com/user-attachments/assets/5e6aac2c-39f2-48ae-9c21-4abd6b179907" />

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-199
