### PR TITLE
SCRUM-201: Programming Bug Fixes

### DIFF
--- a/backend/__test__/codeLimit.test.js
+++ b/backend/__test__/codeLimit.test.js
@@ -1,0 +1,339 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          codeLimit.test.js
+//  Description:   Integration tests for programming question
+//                 daily submission limit enforcement in topic
+//                 practice and mock test question fetching.
+//
+//  Dependencies:  supertest
+//                 testHelpers
+//                 mysql2 connection pool (server.js)
+//                 codeLimits
+//
+////////////////////////////////////////////////////////////////
+
+const request = require('supertest');
+const { app, pool } = require('../server');
+const { verifyTestDatabase, getAuthToken, insertQuestion } = require('./testHelpers');
+const { MAX_SUBMISSIONS_PER_DAY } = require('../config/codeLimits');
+
+let token;
+let userId;
+let programmingQuestionId;
+let nonProgrammingIds = []; // To pad the test db so we don't 404
+
+/**
+ * Helper function, inserts a test case for a programming question.
+ * If we end up needing this in another file, extract to testHelper.js
+ * @param {number} questionId - The programming question to attach the test case to
+ * @returns {Promise<number>} Inserted test case ID
+ */
+const insertTestCase = async (questionId) => {
+  const [result] = await pool.query(
+    `INSERT INTO TestCase (QUESTION_ID, INPUT, EXPECTED_OUTPUT) VALUES (?, ?, ?)`,
+    [questionId, '1', '1']
+  );
+  return result.insertId;
+};
+
+/**
+ * Helper function, inserts a programming Response row directly into db,
+ * bypasses Judge0.
+ * @param {number} userId     - User who submitted
+ * @param {number} questionId - Programming question to submit for
+ */
+const insertProgrammingResponse = async (userId, questionId) => {
+  await pool.query(
+    `INSERT INTO Response 
+     (USERID, PROBLEM_ID, USER_ANSWER, ISCORRECT, POINTS_EARNED, POINTS_POSSIBLE, CATEGORY, TOPIC)
+     VALUES (?, ?, ?, FALSE, 0, 2, 'Test Category', 'Test Topic')`,
+    [userId, questionId, JSON.stringify({ type: 'Programming', language: 'Python', code: 'pass' })]
+  );
+};
+
+beforeAll(async () => {
+  await verifyTestDatabase(pool);
+  token = await getAuthToken();
+
+  // Get userId from token
+  const [rows] = await pool.query(
+    `SELECT ID FROM User WHERE USERNAME = 'testuser' LIMIT 1`
+  );
+  userId = rows[0].ID;
+
+  // Insert a published prog question in section A with one test case
+  // This will need updating once SCRUM-199 goes in
+  programmingQuestionId = await insertQuestion('Programming', [], 2.00);
+  await pool.query(
+    `UPDATE Question SET IS_PUBLISHED = 1, SUBCATEGORY = 'Test Topic', SECTION = 'A' WHERE ID = ?`,
+    [programmingQuestionId]
+  );
+  await insertTestCase(programmingQuestionId);
+
+  // Pad db with non-programming questions so tests don't 404
+  // if the topic practice/mock test endpoints skip programming questions
+  const sectionsAndTopics = [
+    { section: 'A', topic: 'Test Topic' },
+    { section: 'A', topic: 'Test Topic' },
+    { section: 'A', topic: 'Test Topic' },
+    { section: 'B', topic: 'Test Topic B' },
+    { section: 'B', topic: 'Test Topic B' },
+    { section: 'B', topic: 'Test Topic B' },
+    { section: 'C', topic: 'Test Topic C' },
+    { section: 'C', topic: 'Test Topic C' },
+    { section: 'C', topic: 'Test Topic C' },
+    { section: 'D', topic: 'Test Topic D' },
+    { section: 'D', topic: 'Test Topic D' },
+    { section: 'D', topic: 'Test Topic D' },
+  ];
+
+  // Insert questions
+  for (const { section, topic } of sectionsAndTopics) 
+  {
+    // This will need updating once SCRUM-199 goes in
+    const id = await insertQuestion('Multiple Choice', 
+    [
+      { text: 'Answer', isCorrect: true }
+    ], 2.00);
+    await pool.query(
+      `UPDATE Question SET IS_PUBLISHED = 1, SUBCATEGORY = ?, SECTION = ? WHERE ID = ?`,
+      [topic, section, id]
+    );
+    nonProgrammingIds.push(id);
+  }
+});
+
+afterEach(async () => {
+  // Clear programming responses between tests so limit resets
+  await pool.query(
+    `DELETE FROM Response WHERE USERID = ? AND PROBLEM_ID = ?`,
+    [userId, programmingQuestionId]
+  );
+});
+
+afterAll(async () => {
+  // Clean up
+  await pool.query(`DELETE FROM TestCase WHERE QUESTION_ID = ?`, [programmingQuestionId]);
+  await pool.query(`DELETE FROM Question WHERE ID = ?`, [programmingQuestionId]);
+
+  if (nonProgrammingIds.length > 0) 
+  {
+    await pool.query(
+      `DELETE FROM Question WHERE ID IN (${nonProgrammingIds.map(() => '?').join(',')})`,
+      nonProgrammingIds
+    );
+  }
+
+  try 
+  {
+    await pool.end();
+  } 
+  catch (err) 
+  {
+    console.error("Error closing pool in codeLimit.test.js:", err);
+  }
+});
+
+// Test code/canSubmit endpoint
+describe('GET /api/code/canSubmit', () => {
+  test('returns canSubmit: true and full remaining count when user has no submissions today', async () => {
+    const res = await request(app)
+      .get('/api/code/canSubmit')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.canSubmit).toBe(true);
+    expect(res.body.remaining).toBe(MAX_SUBMISSIONS_PER_DAY);
+  });
+
+  test('returns decremented remaining count after submissions', async () => {
+    // Two responses
+    await insertProgrammingResponse(userId, programmingQuestionId);
+    await insertProgrammingResponse(userId, programmingQuestionId);
+
+    const res = await request(app)
+      .get('/api/code/canSubmit')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.canSubmit).toBe(true); // Can still submit
+    // Should have decremented by 2
+    expect(res.body.remaining).toBe(MAX_SUBMISSIONS_PER_DAY - 2);
+  });
+
+  test('returns canSubmit: false and remaining: 0 when limit is reached', async () => {
+    // Reach submit limit
+    for (let i = 0; i < MAX_SUBMISSIONS_PER_DAY; i++) 
+    {
+      await insertProgrammingResponse(userId, programmingQuestionId);
+    }
+
+    const res = await request(app)
+      .get('/api/code/canSubmit')
+      .set('Authorization', `Bearer ${token}`);
+
+    // No more submits!
+    expect(res.status).toBe(200);
+    expect(res.body.canSubmit).toBe(false);
+    expect(res.body.remaining).toBe(0);
+  });
+
+  test('returns 401 when no token provided', async () => {
+    const res = await request(app)
+      .get('/api/code/canSubmit');
+
+    expect(res.status).toBe(401);
+  });
+
+  test('does not count test runs against remaining submissions', async () => {
+    // Insert a test run
+    await pool.query(
+      'INSERT INTO TestRun (USERID, QUESTION_ID) VALUES (?, ?)',
+      [userId, programmingQuestionId]
+    );
+
+    const res = await request(app)
+      .get('/api/code/canSubmit')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.canSubmit).toBe(true);
+    // Should still have full daily submissions
+    expect(res.body.remaining).toBe(MAX_SUBMISSIONS_PER_DAY);
+
+    // Cleanup
+    await pool.query(
+      'DELETE FROM TestRun WHERE USERID = ? AND QUESTION_ID = ?',
+      [userId, programmingQuestionId]
+    );
+  });
+});
+
+// Test topic practice fetching
+// If a user has no more daily submissions,
+// topic practice should not give them a programming question.
+// Otherwise, topic practice should give the user a maximum
+// of one programming question per topic practice generation.
+describe('GET /api/test/topic/:topicName - programming limit', () => {
+  test('includes programming question when user is under the limit', async () => {
+    const res = await request(app)
+      .get('/api/test/topic/Test Topic')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const types = res.body.map(q => q.TYPE);
+    expect(types).toContain('Programming');
+  });
+
+  test('excludes programming question when user has reached the limit', async () => {
+    // Reach limit
+    for (let i = 0; i < MAX_SUBMISSIONS_PER_DAY; i++) 
+    {
+      await insertProgrammingResponse(userId, programmingQuestionId);
+    }
+
+    const res = await request(app)
+      .get('/api/test/topic/Test Topic')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const types = res.body.map(q => q.TYPE);
+    // Shouldn't have any programming questions
+    expect(types).not.toContain('Programming');
+  });
+
+  test('includes at most one programming question regardless of how many exist', async () => {
+    // Insert a second published programming question in the same topic
+    // This will need updating once SCRUM-199 goes in
+    const secondId = await insertQuestion('Programming', [], 2.00);
+    await pool.query(
+      `UPDATE Question SET IS_PUBLISHED = 1, SUBCATEGORY = 'Test Topic', SECTION = 'A' WHERE ID = ?`,
+      [secondId]
+    );
+
+    const res = await request(app)
+      .get('/api/test/topic/Test Topic')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const programmingQuestions = res.body.filter(q => q.TYPE === 'Programming');
+    // Should still not exceed 1 in the set
+    expect(programmingQuestions.length).toBeLessThanOrEqual(1);
+
+    // Cleanup
+    await pool.query(`DELETE FROM Question WHERE ID = ?`, [secondId]);
+  });
+});
+
+// Test mock test fetching
+// Just like topic practice, if a user has no more daily submissions,
+// mock test should not give them a programming question.
+// Otherwise, mock test should give the user a maximum
+// of one programming question per test.
+describe('GET /api/test/mocktest - programming limit', () => {
+  test('includes at most one programming question when user is under the limit', async () => {
+    const res = await request(app)
+      .get('/api/test/mocktest')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const programmingQuestions = res.body.questions.filter(q => q.TYPE === 'Programming');
+    expect(programmingQuestions.length).toBeLessThanOrEqual(1);
+  });
+
+  test('excludes programming questions when user has reached the limit', async () => {
+    // Hit limit
+    for (let i = 0; i < MAX_SUBMISSIONS_PER_DAY; i++) 
+    {
+      await insertProgrammingResponse(userId, programmingQuestionId);
+    }
+
+    const res = await request(app)
+      .get('/api/test/mocktest')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const programmingQuestions = res.body.questions.filter(q => q.TYPE === 'Programming');
+    // Should never contain one
+    expect(programmingQuestions.length).toBe(0);
+  });
+
+  // Very important; even if the user can't get a programming
+  // question in a mock test, they still need 3 non-programming questions
+  // from each of the 4 sections.
+  test('still returns 3 questions from each of the 4 sections when programming is excluded', async () => {
+    // Hit limit
+    for (let i = 0; i < MAX_SUBMISSIONS_PER_DAY; i++) 
+    {
+      await insertProgrammingResponse(userId, programmingQuestionId);
+    }
+
+    const res = await request(app)
+      .get('/api/test/mocktest')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    
+    // Count up number of questions in each of the 4 sections
+    const questionsBySection = res.body.questions.reduce((acc, q) => {
+      acc[q.SECTION] = (acc[q.SECTION] || 0) + 1;
+      return acc;
+    }, {});
+
+    expect(Object.keys(questionsBySection).sort()).toEqual(['A', 'B', 'C', 'D']);
+    expect(questionsBySection['A']).toBe(3);
+    expect(questionsBySection['B']).toBe(3);
+    expect(questionsBySection['C']).toBe(3);
+    expect(questionsBySection['D']).toBe(3);
+  });
+
+  test('returns 401 when no token provided', async () => {
+    const res = await request(app)
+      .get('/api/test/mocktest');
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/__test__/codeLimit.test.js
+++ b/backend/__test__/codeLimit.test.js
@@ -65,8 +65,7 @@ beforeAll(async () => {
   userId = rows[0].ID;
 
   // Insert a published prog question in section A with one test case
-  // This will need updating once SCRUM-199 goes in
-  programmingQuestionId = await insertQuestion('Programming', [], 2.00);
+  programmingQuestionId = await insertQuestion('Programming', [], { points: 2.00 });
   await pool.query(
     `UPDATE Question SET IS_PUBLISHED = 1, SUBCATEGORY = 'Test Topic', SECTION = 'A' WHERE ID = ?`,
     [programmingQuestionId]
@@ -93,11 +92,10 @@ beforeAll(async () => {
   // Insert questions
   for (const { section, topic } of sectionsAndTopics) 
   {
-    // This will need updating once SCRUM-199 goes in
     const id = await insertQuestion('Multiple Choice', 
     [
       { text: 'Answer', isCorrect: true }
-    ], 2.00);
+    ], { points: 2.00 });
     await pool.query(
       `UPDATE Question SET IS_PUBLISHED = 1, SUBCATEGORY = ?, SECTION = ? WHERE ID = ?`,
       [topic, section, id]
@@ -247,8 +245,7 @@ describe('GET /api/test/topic/:topicName - programming limit', () => {
 
   test('includes at most one programming question regardless of how many exist', async () => {
     // Insert a second published programming question in the same topic
-    // This will need updating once SCRUM-199 goes in
-    const secondId = await insertQuestion('Programming', [], 2.00);
+    const secondId = await insertQuestion('Programming', [], { points: 2.00 });
     await pool.query(
       `UPDATE Question SET IS_PUBLISHED = 1, SUBCATEGORY = 'Test Topic', SECTION = 'A' WHERE ID = ?`,
       [secondId]

--- a/backend/__test__/prof.test.js
+++ b/backend/__test__/prof.test.js
@@ -848,7 +848,7 @@ describe("Admin Routes - Draft/Publish", () => {
     const { profId, token } = await insertProf(pool, "draftcheckprof", "draftcheck@ucf.edu", 1);
 
     // Insert draft queston for the professor
-    await insertQuestion("MCQ", [], false, profId);
+    await insertQuestion("MCQ", [], { isPublished: false, ownerId: profId });
 
     const res = await request(app)
       .get("/api/admin/published")

--- a/backend/config/codeLimits.js
+++ b/backend/config/codeLimits.js
@@ -4,7 +4,8 @@
 //  Year:          2026
 //  Author(s):     Daniel Landsman
 //  File:          codeLimits.js
-//  Description:   Config file used to set code submission limits
+//  Description:   Config file used to set and check code 
+//                 submission limits.
 //                 Numbers may need fine-tuning
 //
 ////////////////////////////////////////////////////////////////
@@ -34,10 +35,29 @@ const MAX_TEST_RUNS_PER_PROBLEM = 3;
  * const MAX_MEMORY_KB = TBD
  */
 
+/**
+ * Checks how many programming question submissions a user has remaining today.
+ * @param {object} db     - Database connection
+ * @param {number} userId - User ID
+ * @returns {Promise<number>} - Number of submissions remaining today (0 means limit reached)
+ */
+const getProgrammingSubmissionsRemaining = async (db, userId) => {
+  const [[{ numDailyResponses }]] = await db.query(
+    `SELECT COUNT(*) as numDailyResponses
+     FROM Response r
+     JOIN Question q ON r.PROBLEM_ID = q.ID
+     WHERE r.USERID = ? AND q.TYPE = 'Programming' AND DATE(DATETIME) = CURDATE()`,
+    [userId]
+  );
+
+  return Math.max(0, MAX_SUBMISSIONS_PER_DAY - numDailyResponses);
+};
+
 module.exports = {
     MAX_CODE_BYTES,
     MAX_SUBMISSIONS_PER_DAY,
     MAX_TEST_RUNS_PER_PROBLEM,
     // MAX_RUNTIME_MS,
-    // MAX_MEMORY_KB
+    // MAX_MEMORY_KB,
+    getProgrammingSubmissionsRemaining,
 }

--- a/backend/controllers/codeController.js
+++ b/backend/controllers/codeController.js
@@ -269,16 +269,18 @@ const submitCode = asyncHandler(async (req, res) => {
           POINTS_EARNED,
           POINTS_POSSIBLE,
           CATEGORY,
-          TOPIC
+          TOPIC,
+          DATETIME
         ) 
-        VALUES (?, ?, ?, FALSE, 0, ?, ?, ?)`,
+        VALUES (?, ?, ?, FALSE, 0, ?, ?, ?, ?)`,
         [
           userId, 
           problemId, 
           serializedCode,
           question.POINTS_POSSIBLE, 
           question.CATEGORY, 
-          question.SUBCATEGORY
+          question.SUBCATEGORY,
+          new Date()
         ]
       );
     }
@@ -286,6 +288,11 @@ const submitCode = asyncHandler(async (req, res) => {
     return res.status(200).json({
       success: false,
       isTestRun: isTestRun,
+      allPassed: false,
+      passedTests: 0,
+      totalTests: testCases.length,
+      pointsEarned: 0,
+      pointsPossible: parseFloat(question.POINTS_POSSIBLE),
       status: errorResult.status.description,
       error: errorResult.stderr || errorResult.compile_output || 'Execution failed',
       message: 'Your code failed to execute. Please check for errors.'
@@ -328,9 +335,10 @@ const submitCode = asyncHandler(async (req, res) => {
       POINTS_EARNED,
       POINTS_POSSIBLE,
       CATEGORY,
-      TOPIC
+      TOPIC,
+      DATETIME
     ) 
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       userId, 
       problemId, 
@@ -339,7 +347,8 @@ const submitCode = asyncHandler(async (req, res) => {
       gradingResults.pointsEarned, 
       question.POINTS_POSSIBLE, 
       question.CATEGORY, 
-      question.SUBCATEGORY
+      question.SUBCATEGORY,
+      new Date()
     ]
   );
 

--- a/backend/controllers/codeController.js
+++ b/backend/controllers/codeController.js
@@ -15,7 +15,12 @@
 
 const judge0Service = require('../services/judge0Service');
 const { asyncHandler, AppError } = require('../middleware/errorHandler');
-const { MAX_CODE_BYTES, MAX_SUBMISSIONS_PER_DAY, MAX_TEST_RUNS_PER_PROBLEM } = require('../config/codeLimits'); 
+const { 
+        MAX_CODE_BYTES,
+        MAX_SUBMISSIONS_PER_DAY,
+        MAX_TEST_RUNS_PER_PROBLEM,
+        getProgrammingSubmissionsRemaining,
+      } = require('../config/codeLimits'); 
 const { awardCurrency } = require('../utils/currencyUtils');
 
 /**
@@ -116,7 +121,7 @@ const serializeProgrammingAnswer = (code, languageId) => {
 };
 
 /**
- * @route   POST /api/codeSubmission/submitCode
+ * @route   POST /api/code/submitCode
  * @desc    Submit code to Judge0, receive output and grade against test cases.
  *          Supports test runs, which submits to Judge0 but doesn't grade output
  *          or store as a response, just runs against first test case, shows output, 
@@ -349,9 +354,29 @@ const submitCode = asyncHandler(async (req, res) => {
     passedTests: gradingResults.passedTests,
     totalTests: gradingResults.totalTests,
     pointsEarned: gradingResults.pointsEarned,
-    pointsPossible: question.POINTS_POSSIBLE,
+    pointsPossible: parseFloat(question.POINTS_POSSIBLE),
     testResults: gradingResults.testResults
   });
 });
 
-module.exports = { submitCode };
+/**
+ * @route   GET /api/code/canSubmit
+ * @desc    Fetch whether the user still has remaining code submission
+ *          attempts for the day, as well as their number of remaining
+ *          submissions for the day.
+ * @access  Protected
+ * 
+ * @param   {import('express').Request}  req - Express request object
+ * @param   {import('express').Response} res - Express response object
+ * @returns {Promise<void>}                  - Sends HTTP/JSON response
+ */
+const canSubmit = asyncHandler(async (req, res) => {
+  // Get number of remaining code submissions for today
+  const remaining = await getProgrammingSubmissionsRemaining(req.db, req.user.id);
+  return res.status(200).json({ canSubmit: remaining > 0, remaining });
+});
+
+module.exports = { 
+  submitCode,
+  canSubmit,
+};

--- a/backend/routes/codeSubmission.js
+++ b/backend/routes/codeSubmission.js
@@ -16,13 +16,22 @@
 const express = require("express");
 const router = express.Router();
 const authMiddleware = require("../middleware/authMiddleware");
-const { submitCode } = require("../controllers/codeController");
+const { submitCode, canSubmit } = require("../controllers/codeController");
 
 /**
- * @route   POST /api/codeSubmission/submitCode
+ * @route   POST /api/code/submitCode
  * @desc    Submit code to Judge0, receive output and grade against test cases.
  * @access  Protected
  */
 router.post("/submitCode", authMiddleware, submitCode);
+
+/**
+ * @route   GET /api/code/canSubmit
+ * @desc    Fetch whether the user still has remaining code submission
+ *          attempts for the day, as well as their number of remaining
+ *          submissions for the day.
+ * @access  Protected
+ */
+router.get("/canSubmit", authMiddleware, canSubmit);
 
 module.exports = router;

--- a/backend/routes/testRoutes.js
+++ b/backend/routes/testRoutes.js
@@ -13,6 +13,7 @@
 //                 errorHandler
 //                 gradingController
 //                 currencyUtils
+//                 codeLimits (daily submission check)
 //
 ////////////////////////////////////////////////////////////////
 
@@ -22,6 +23,7 @@ const authMiddleware = require("../middleware/authMiddleware");
 const { asyncHandler, AppError } = require("../middleware/errorHandler");
 const { gradeQuestion } = require("../controllers/gradingController");
 const { awardCurrency } = require("../utils/currencyUtils");
+const { getProgrammingSubmissionsRemaining } = require("../config/codeLimits");
 
 /**
  * Helper function, gets answers for given questions, pairs them with each question
@@ -93,6 +95,13 @@ const serializeUserAnswer = (questionType, userAnswer) => {
 /**
  * @route   GET /api/test/topic/:topicName
  * @desc    Fetch published questions for a given subcategory (e.g. Backtracking)
+ *          Maximum of 1 programming question, or 0
+ *          if user has reached the max daily submission
+ *          limit for programming questions.
+ *          WARNING: THIS ENDPOINT IS INTENDED ONLY FOR GENERATING TOPIC PRACTICE SESSIONS.
+ *          Programming questions may be silently filtered out based on the requesting
+ *          user's daily submission limit. Using this endpoint as a general question
+ *          enumerator may return incomplete results.
  * @access  Protected
  * 
  * @param {import('express').Request}  req - Express request object
@@ -113,13 +122,28 @@ router.get("/topic/:topicName", authMiddleware, asyncHandler(async (req, res) =>
     throw new AppError(`No published questions exist for subcategory: ${topicName}`, 404, "Question not found");
   }
 
-  const questionsWithAnswers = await pairAnswersWithQuestions(questions, req.db);
+  // If user reached programming question daily submission limit,
+  // filter out programming questions
+  // Otherwise only allow one programming question to be included
+  const remaining = await getProgrammingSubmissionsRemaining(req.db, req.user.id);
+  let programmingQuestionUsed = false;
+  const filtered = questions.filter(q => {
+    if (q.TYPE !== 'Programming') return true;
+    if ( !(remaining > 0) || programmingQuestionUsed) return false;
+    programmingQuestionUsed = true;
+    return true;
+  });
+
+  const questionsWithAnswers = await pairAnswersWithQuestions(filtered, req.db);
   res.json(questionsWithAnswers);
 }));
 
 /**
  * @route   GET /api/test/mocktest
  * @desc    Fetch questions info for a mock test
+ *          Maximum of 1 programming question, or 0
+ *          if user has reached the max daily submission
+ *          limit for programming questions.
  * @access  Protected
  * 
  * @param {import('express').Request}  req - Express request object
@@ -130,10 +154,19 @@ router.get("/mocktest", authMiddleware, asyncHandler(async (req, res) => {
   const sections = ["A", "B", "C", "D"];
   const questionsBySection = {};
 
+  // Check if user has reached the daily limit for programming questions
+  const remaining = await getProgrammingSubmissionsRemaining(req.db, req.user.id);
+
   // shuffled problem per section and pick three published questions randomly
+  let programmingQuestionUsed = false;
   for (const section of sections) {
+    // Don't include programming in the query if:
+    // - User is at daily submission limit
+    // - We've already included one programming question
+    const excludeProgramming = !(remaining > 0) || programmingQuestionUsed;
     const [questions] = await req.db.query(
-      'SELECT * FROM Question WHERE SECTION = ? AND IS_PUBLISHED = 1',
+      `SELECT * FROM Question WHERE SECTION = ? AND IS_PUBLISHED = 1
+      ${excludeProgramming ? "AND TYPE != 'Programming'" : ""}`,
       [section]
     );
 
@@ -142,7 +175,14 @@ router.get("/mocktest", authMiddleware, asyncHandler(async (req, res) => {
       throw new AppError(`Published question not found in section: ${section}`, 404, "Question not found");
     }
     const shuffled = questions.sort(() => 0.5 - Math.random());
-    questionsBySection[section] = shuffled.slice(0, 3);
+    const picked = shuffled.slice(0, 3);
+    questionsBySection[section] = picked;
+
+    // We included a programming question, so don't include any additional
+    if (!programmingQuestionUsed && picked.some(q => q.TYPE === 'Programming')) 
+    {
+      programmingQuestionUsed = true;
+    }
   }
 
   const allQuestions = Object.values(questionsBySection).flat();

--- a/backend/services/judge0Service.js
+++ b/backend/services/judge0Service.js
@@ -64,13 +64,16 @@ const submitBatch = async (sourceCode, languageId, testCases) => {
   // Create batch submissions
   const submissions = testCases.map(testCase => (
   {
-    source_code: sourceCode,
+    source_code: Buffer.from(sourceCode).toString('base64'),
     language_id: languageId,
-    stdin: testCase.INPUT || '',
+    stdin: testCase.INPUT ? Buffer.from(testCase.INPUT).toString('base64') : '',
     expected_output: testCase.EXPECTED_OUTPUT
+      ? Buffer.from(testCase.EXPECTED_OUTPUT).toString('base64')
+      : '',
   }));
 
-  const response = await fetch(`${JUDGE0_API_URL}/submissions/batch`, {
+  // Use base64 encoding to work with Judge0's UTF-8 parsing
+  const response = await fetch(`${JUDGE0_API_URL}/submissions/batch?base64_encoded=true`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -103,7 +106,7 @@ const submitBatch = async (sourceCode, languageId, testCases) => {
  */
 const getSubmission = async (token) => {
   const response = await fetch(
-    `${JUDGE0_API_URL}/submissions/${token}`,
+    `${JUDGE0_API_URL}/submissions/${token}?base64_encoded=true`,
     {
       method: 'GET',
       headers: 
@@ -115,6 +118,11 @@ const getSubmission = async (token) => {
   );
 
   const data = await response.json();
+
+  // Decode response fields from base64
+  if (data.stdout) data.stdout = Buffer.from(data.stdout, 'base64').toString('utf8');
+  if (data.stderr) data.stderr = Buffer.from(data.stderr, 'base64').toString('utf8');
+  if (data.compile_output) data.compile_output = Buffer.from(data.compile_output, 'base64').toString('utf8');
 
   if (!response.ok) 
   {

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -916,14 +916,51 @@ paths:
           description: Server Error
         502:
           description: Judge0 Service Unavailable
+        
+  /code/canSubmit:
+    get:
+      tags:
+        - Problems
+      summary: Check whether the user can submit any more programming responses today.
+      operationId: canSubmit
+      description: |
+        Checks the user's number of programming question submissions today and compares
+        it to the maximum daily submission limit.
+        Returns a JSON object with two fields:
+        - canSubmit: true if the user has not yet reached the daily limit, false otherwise.
+        - remaining: the number of programming question submissions the user has left today (0 if limit reached).
+      security:
+        - BearerAuth: []
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              canSubmit:
+                type: boolean
+                example: true
+              remaining:
+                type: integer
+                example: 8
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
 
   /test/topic/{topicName}:
     get:
       tags:
       - Problems
-      summary: Fetch questions for a specific topic.
+      summary: Generate a topic practice session for a specific topic.
       operationId: getTopicQuestions
-      description: Retrieves all published questions for a given subcategory (e.g., Backtracking, Recursion).
+      description: |
+        Retrieves all published questions for a given subcategory (e.g., Backtracking, Recursion).
+        Programming questions are subject to the following restrictions:
+        - At most one programming question is included per topic practice session.
+        - If the user has reached their daily programming submission limit, no programming questions are included.
       security:
         - BearerAuth: []
       parameters:
@@ -948,7 +985,11 @@ paths:
       - Problems
       summary: Generate a mock test.
       operationId: getMockTest
-      description: Retrieves a randomly generated mock test with published questions from all sections (A, B, C, D).
+      description: |
+        Retrieves a randomly generated mock test with published questions from all sections (A, B, C, D).
+        Programming questions are subject to the following restrictions:
+        - At most one programming question is included per mock test.
+        - If the user has reached their daily programming submission limit, no programming questions will be included in the mock test.
       security:
         - BearerAuth: []
       responses:

--- a/frontend/src/components/Programming.tsx
+++ b/frontend/src/components/Programming.tsx
@@ -30,6 +30,16 @@ type Props = {
   setSelectedLanguage: (val: string) => void; // update selected language
   handleSubmit: () => void; // click submit
   handleNext: () => void; // click next
+  answered?: boolean; // if user submitted response
+  isSubmitting?: boolean; // loading state
+  isCorrect?: boolean; // check correct answer
+  feedbackText?: string; // optional grader feedback
+  pointsEarned?: number | null; // points earned
+  pointsPossible?: number | null; // points possible
+  normalizedScore?: number | null; // normalized score (0-1)
+  passedTests?: number | null; // number of passed test cases
+  totalTests?: number | null; // total number of test cases
+  submissionsRemaining?: number | null; // number of submits until daily limit reached
 };
 
 const Programming: React.FC<Props> = ({
@@ -42,6 +52,16 @@ const Programming: React.FC<Props> = ({
   setSelectedLanguage,
   handleSubmit,
   handleNext,
+  answered = false,
+  isSubmitting = false,
+  isCorrect = false,
+  feedbackText,
+  pointsEarned,
+  pointsPossible,
+  normalizedScore,
+  passedTests = null,
+  totalTests = null,
+  submissionsRemaining = null,
 }) => {
   const [consoleOutput, setConsoleOutput] = useState<string>("");
   const [isRunning, setIsRunning] = useState(false);
@@ -313,20 +333,88 @@ const Programming: React.FC<Props> = ({
         </div>
       </div>
 
-      {/* submit/next buttons */}
+      {/* grading feedback */}
+      {answered && (
+        <div className="mb-6">
+          {(() => {
+            const score = typeof normalizedScore === "number"
+              ? normalizedScore
+              : isCorrect ? 1 : 0;
+            const statusClass = score >= 1
+              ? "text-green-600"
+              : score > 0.5
+              ? "text-yellow-600"
+              : "text-red-600";
+            const boxClass = score >= 1
+              ? "bg-green-50"
+              : score > 0.5
+              ? "bg-yellow-50"
+              : "bg-red-50";
+            const borderClass = score >= 1
+              ? "border-green-500"
+              : score > 0.5
+              ? "border-yellow-500"
+              : "border-red-500";
+
+            const derivedPointsPossible =
+              typeof pointsPossible === "number"
+                ? pointsPossible
+                : typeof current.POINTS_POSSIBLE === "number"
+                ? current.POINTS_POSSIBLE
+                : null;
+            const derivedPointsEarned =
+              typeof pointsEarned === "number"
+                ? pointsEarned
+                : typeof normalizedScore === "number" && derivedPointsPossible !== null
+                ? Math.round(normalizedScore * derivedPointsPossible * 100) / 100
+                : null;
+
+            return (
+              <div className={`p-4 ${boxClass} rounded border ${borderClass} text-sm sm:text-base md:text-lg`}>
+                {feedbackText && (
+                  <p className={statusClass}>{feedbackText}</p>
+                )}
+                <div className="mt-2 text-gray-700 space-y-1">
+                  {derivedPointsEarned !== null && derivedPointsPossible !== null && (
+                    <p>Points: {derivedPointsEarned} / {derivedPointsPossible}</p>
+                  )}
+                  {passedTests !== null && totalTests !== null && (
+                    <p>Test cases passed: {passedTests} / {totalTests}</p>
+                  )}
+                </div>
+              </div>
+            );
+          })()}
+          {submissionsRemaining === 0 && (
+            <div className="mt-3 p-3 bg-yellow-50 border border-yellow-400 rounded text-sm text-yellow-800">
+              You've now used all your programming submissions for today. Come back tomorrow for more!
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* submit/next buttons (next appears after submit) */}
       <div className="flex gap-4 justify-end mt-8 border-t pt-6">
-        <button
-          onClick={handleSubmit}
-          className="px-6 sm:px-8 py-2 sm:py-3 rounded-full shadow font-semibold text-sm sm:text-base bg-yellow-400 hover:bg-yellow-500 text-black"
-        >
-          Submit
-        </button>
-        <button
-          onClick={handleNext}
-          className="px-6 sm:px-8 py-2 sm:py-3 rounded-full shadow font-semibold text-sm sm:text-base bg-yellow-400 hover:bg-yellow-500 text-black"
-        >
-          {currentIndex + 1 === total ? "Result" : "Next"}
-        </button>
+        {!answered ? (
+          <button
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+            className={`px-6 sm:px-8 py-2 sm:py-3 rounded-full shadow font-semibold text-sm sm:text-base ${
+              isSubmitting
+                ? "bg-yellow-200 text-gray-500 cursor-not-allowed"
+                : "bg-yellow-400 hover:bg-yellow-500 text-black"
+            }`}
+          >
+            {isSubmitting ? "Grading..." : "Submit"}
+          </button>
+        ) : (
+          <button
+            onClick={handleNext}
+            className="px-6 sm:px-8 py-2 sm:py-3 rounded-full shadow font-semibold text-sm sm:text-base bg-yellow-400 hover:bg-yellow-500 text-black"
+          >
+            {currentIndex + 1 === total ? "Result" : "Next"}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/Programming.tsx
+++ b/frontend/src/components/Programming.tsx
@@ -10,6 +10,7 @@
 //                 html-react-parser
 //                 dompurify
 //                 models (Question)
+//                 axios (isAxiosError)
 //
 ////////////////////////////////////////////////////////////////
 
@@ -19,6 +20,7 @@ import parse from "html-react-parser";
 import DOMPurify from "dompurify";
 import { Question } from "../models";
 import api from "../api";
+import { isAxiosError } from "axios";
 
 type Props = {
   current: Question; // current question
@@ -173,21 +175,30 @@ const Programming: React.FC<Props> = ({
     } catch (error) {
       // Log full error details for debugging
       console.error("Code execution error:", error);
-      if (error && typeof error === 'object' && 'response' in error) {
-        const axiosError = error as { response?: { status?: number; data?: { error?: string; message?: string }; statusText?: string } };
-        console.error("Backend response:", {
-          status: axiosError.response?.status,
-          statusText: axiosError.response?.statusText,
-          data: axiosError.response?.data,
-        });
-        const errorMsg = axiosError.response?.data?.error 
-          || axiosError.response?.data?.message
-          || axiosError.response?.statusText
-          || "Network error occurred";
-        setConsoleOutput(`Failed to run code (${axiosError.response?.status || 'unknown'}): ${errorMsg}`);
-      } else {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        setConsoleOutput(`Failed to run code: ${errorMessage}`);
+
+      // Test run limit reached
+      if (isAxiosError(error) && error.response?.status === 429)
+      {
+        setConsoleOutput("Daily test run limit for this question exceeded. Submit your response to see your results!");
+      }   
+      else // All other errors
+      { 
+        if (error && typeof error === 'object' && 'response' in error) {
+          const axiosError = error as { response?: { status?: number; data?: { error?: string; message?: string }; statusText?: string } };
+          console.error("Backend response:", {
+            status: axiosError.response?.status,
+            statusText: axiosError.response?.statusText,
+            data: axiosError.response?.data,
+          });
+          const errorMsg = axiosError.response?.data?.error 
+            || axiosError.response?.data?.message
+            || axiosError.response?.statusText
+            || "Network error occurred";
+          setConsoleOutput(`Failed to run code (${axiosError.response?.status || 'unknown'}): ${errorMsg}`);
+        } else {
+          const errorMessage = error instanceof Error ? error.message : "Unknown error";
+          setConsoleOutput(`Failed to run code: ${errorMessage}`);
+        }
       }
     } finally {
       setIsRunning(false);
@@ -327,7 +338,7 @@ const Programming: React.FC<Props> = ({
           <h4 className="text-sm font-semibold mb-2">Console Output</h4>
           <div className="p-4 bg-black rounded-lg border border-gray-700 min-h-[120px] max-h-[200px] overflow-auto">
             <pre className="text-gray-300 font-mono text-xs sm:text-sm whitespace-pre-wrap break-words">
-              {consoleOutput || "Run your code to see output here..."}
+              {consoleOutput ||  'Click "Run" to see your code executed with the example input.'}
             </pre>
           </div>
         </div>

--- a/frontend/src/pages/MockTestPage.tsx
+++ b/frontend/src/pages/MockTestPage.tsx
@@ -14,6 +14,7 @@
 //                 SelectAllThatApply component
 //                 MockTestResult component
 //                 models (Question, MockTestResponse)
+//                 axios (isAxiosError)
 //
 ////////////////////////////////////////////////////////////////
 
@@ -29,6 +30,7 @@ import DragAndDrop from "../components/DragAndDrop";
 import Programming from "../components/Programming";
 import api from "../api";
 import { Question, MockTestResponse } from "../models";
+import { isAxiosError } from "axios";
 
 const MockTestPage: React.FC = () => {
   const isProfessorAccount = localStorage.getItem("account_type") === "professor";
@@ -51,6 +53,9 @@ const MockTestPage: React.FC = () => {
   const [normalizedScore, setNormalizedScore] = useState<number | null>(null);
   const [programmingAnswer, setProgrammingAnswer] = useState("");
   const [programmingLanguage, setProgrammingLanguage] = useState("C");
+  const [passedTests, setPassedTests] = useState<number | null>(null);
+  const [totalTests, setTotalTests] = useState<number | null>(null);
+  const [progSubmitsRemaining, setProgSubmitsRemaining] = useState<number | null>(null);
   const programmingLanguageIds: Record<string, number> = {
     C: 50,
     "C++": 54,
@@ -132,11 +137,11 @@ const MockTestPage: React.FC = () => {
                   correctAnswer: ans.TEXT,
                 }))
               : undefined,
-            // programming: use standard languages (C, Java, Python)
+            // programming: use standard languages (C, C++, Java, Python)
             problem:        normalizedType === "programming"
               ? {
                   description: question.QUESTION_TEXT,
-                  languages: ["C", "Java", "Python"],
+                  languages: ["C", "C++", "Java", "Python"],
                 }
               : undefined,
             problemCode:    normalizedType === "programming"
@@ -153,6 +158,22 @@ const MockTestPage: React.FC = () => {
               question.QUESTION_TYPE !== undefined
           );
 
+        // Check and set how many programming submissions
+        // the user has left for the day.
+        const token = localStorage.getItem("token");
+        try 
+        {
+          const limitRes = await api.get(
+            "/api/code/canSubmit",
+            token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
+          );
+          setProgSubmitsRemaining(limitRes.data.remaining);
+        } 
+        catch 
+        {
+          // Just set the questions normally
+        }
+        
         setQuestions(withOptions);
         setSectionScores({});
         setCurrentIndex(0);
@@ -264,8 +285,31 @@ const MockTestPage: React.FC = () => {
         );
 
         const data = result.data;
-        const isCorrect = data.success ? data.correct : false;
+
+        // Decrement remaining submits
+        // Backend counts all submits toward daily limit,
+        // regardless of correct/incorrect/error,
+        // as long as the response is a 200.
+        setProgSubmitsRemaining(prev => prev !== null ? prev - 1 : null);
+
+        const isCorrect = data.success ? data.allPassed : false;
         setIsCorrectAnswer(isCorrect);
+
+        if (data.success)
+        {
+          const passed = data.passedTests ?? 0;
+          const total = data.totalTests ?? 0;
+          const label = data.allPassed ? "Correct!" : passed > 0 ? "Not quite!" : "Incorrect.";
+          setGradingFeedback(label);
+          setPassedTests(passed);
+          setTotalTests(total);
+          setPointsEarned(typeof data.pointsEarned === "number" ? data.pointsEarned : null);
+          setPointsPossible(typeof data.pointsPossible === "number" ? data.pointsPossible : null);
+        }
+        else
+        {
+          setGradingFeedback(`${data.status || "Execution failed. Please try again later."}`);
+        }
 
         const section = current.SECTION;
         setSectionScores((prev) => ({
@@ -275,10 +319,28 @@ const MockTestPage: React.FC = () => {
             total: (prev[section]?.total || 0) + 1,
           },
         }));
-      } catch {
-        console.error("Failed to submit programming response");
+      } catch (error: unknown) {
+        if (isAxiosError(error))
+        {
+          // Daily submission limit reached.
+          // This should never actually be reachable since
+          // the backend should stop serving programming questions to users
+          // once they hit the limit. But just in case.
+          if (error.response?.status === 429)
+          {
+            setGradingFeedback("Daily programming question submission limit exceeded. Come back tomorrow!");
+          }
+          else
+          {
+            setGradingFeedback("Submission failed. Please try again later.");
+          }
+        }
+        else
+        {
+          setGradingFeedback("Submission failed. Please try again later.");
+        }
+        setIsCorrectAnswer(false);
       }
-
       setShowFeedback(true);
       setIsSubmitting(false);
       return;
@@ -352,6 +414,8 @@ const MockTestPage: React.FC = () => {
       setNormalizedScore(null);
       setProgrammingAnswer("");
       setProgrammingLanguage("C");
+      setPassedTests(null);
+      setTotalTests(null);
       setCurrentIndex((prev) => prev + 1);
     }
   };
@@ -428,6 +492,16 @@ const MockTestPage: React.FC = () => {
             setSelectedLanguage={setProgrammingLanguage}
             handleSubmit={handleSubmit}
             handleNext={handleNext}
+            answered={showFeedback}
+            isSubmitting={isSubmitting}
+            isCorrect={isCorrectAnswer}
+            feedbackText={gradingFeedback}
+            pointsEarned={pointsEarned}
+            pointsPossible={pointsPossible}
+            normalizedScore={normalizedScore}
+            passedTests={passedTests}
+            totalTests={totalTests}
+            submissionsRemaining={progSubmitsRemaining}
           />
         ) : questionType === 'select_all_that_apply' ? (
           <SelectAllThatApply

--- a/frontend/src/pages/MockTestPage.tsx
+++ b/frontend/src/pages/MockTestPage.tsx
@@ -295,20 +295,25 @@ const MockTestPage: React.FC = () => {
         const isCorrect = data.success ? data.allPassed : false;
         setIsCorrectAnswer(isCorrect);
 
+        setTotalTests(data.totalTests ?? 0);
+        setPointsPossible(typeof data.pointsPossible === "number" ? data.pointsPossible : null);
+
         if (data.success)
         {
           const passed = data.passedTests ?? 0;
-          const total = data.totalTests ?? 0;
           const label = data.allPassed ? "Correct!" : passed > 0 ? "Not quite!" : "Incorrect.";
           setGradingFeedback(label);
           setPassedTests(passed);
-          setTotalTests(total);
           setPointsEarned(typeof data.pointsEarned === "number" ? data.pointsEarned : null);
-          setPointsPossible(typeof data.pointsPossible === "number" ? data.pointsPossible : null);
         }
         else
         {
-          setGradingFeedback(`${data.status || "Execution failed. Please try again later."}`);
+          // Include compiler/runtime errors when present.
+          const errorDetails = data.compile_output || data.stderr || data.error || "";
+          setPointsEarned(0);
+          setPassedTests(0);
+          setIsCorrectAnswer(false);
+          setGradingFeedback(`${data.status || "Source code error"}${errorDetails ? `: ${errorDetails}` : "."}`);
         }
 
         const section = current.SECTION;

--- a/frontend/src/pages/TopicTestPage.tsx
+++ b/frontend/src/pages/TopicTestPage.tsx
@@ -325,24 +325,25 @@ const TopicTestPage: React.FC = () => {
         // as long as the response is a 200.
         setProgSubmitsRemaining(prev => prev !== null ? prev - 1 : null);
 
+        setTotalTests(data.totalTests ?? 0);
+        setPointsPossible(typeof data.pointsPossible === "number" ? data.pointsPossible : null);
+
         if (data.success) {
           // Show accepted vs incorrect based on judge response.
           const passed = data.passedTests ?? 0;
-          const total = data.totalTests ?? 0;
           const label = data.allPassed ? "Correct!" : passed > 0 ? "Not quite!" : "Incorrect.";
           setFeedback(label);
           setIsCorrectAnswer(Boolean(data.allPassed));
           setPointsEarned(typeof data.pointsEarned === "number" ? data.pointsEarned : null);
           setPointsPossible(typeof data.pointsPossible === "number" ? data.pointsPossible : null);
           setPassedTests(passed);
-          setTotalTests(total);
         } else {
           // Include compiler/runtime errors when present.
           const errorDetails = data.compile_output || data.stderr || data.error || "";
-          setFeedback(`${data.status || "Execution failed"}${errorDetails ? `: ${errorDetails}` : ""}`);
+          setPointsEarned(0);
+          setPassedTests(0);
+          setFeedback(`${data.status || "Source code error"}${errorDetails ? `: ${errorDetails}` : "."}`);
           setIsCorrectAnswer(false);
-          setPassedTests(null);
-          setTotalTests(null);
         }
       } catch (error: unknown) {
         if (isAxiosError(error))

--- a/frontend/src/pages/TopicTestPage.tsx
+++ b/frontend/src/pages/TopicTestPage.tsx
@@ -16,6 +16,7 @@
 //                 FillInTheBlank component
 //                 SelectAllThatApply component
 //                 models (RawQuestion, Question)
+//                 axios (isAxiosError)
 //
 ////////////////////////////////////////////////////////////////
 
@@ -31,6 +32,7 @@ import DragAndDrop from "../components/DragAndDrop";
 import Programming from "../components/Programming";
 import api from "../api";
 import { RawQuestion, Question } from "../models";
+import { isAxiosError } from "axios";
 
 const TopicTestPage: React.FC = () => {
   const { topicName } = useParams<{ topicName: string }>();
@@ -44,6 +46,7 @@ const TopicTestPage: React.FC = () => {
   const [programmingAnswer, setProgrammingAnswer] = useState("");
   const [programmingLanguage, setProgrammingLanguage] = useState("C");
   const [answered, setAnswered] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [correctCount, setCorrectCount] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [feedback, setFeedback] = useState<string>("");
@@ -51,6 +54,10 @@ const TopicTestPage: React.FC = () => {
   const [pointsEarned, setPointsEarned] = useState<number | null>(null);
   const [pointsPossible, setPointsPossible] = useState<number | null>(null);
   const [normalizedScore, setNormalizedScore] = useState<number | null>(null);
+  // These next three are for programming questions only
+  const [passedTests, setPassedTests] = useState<number | null>(null);
+  const [totalTests, setTotalTests] = useState<number | null>(null);
+  const [progSubmitsRemaining, setProgSubmitsRemaining] = useState<number | null>(null);
   const navigate = useNavigate();
   const programmingLanguageIds: Record<string, number> = {
     C: 50,
@@ -200,6 +207,22 @@ const TopicTestPage: React.FC = () => {
               question.QUESTION_TYPE !== undefined
           );
 
+        // Check and set how many programming submissions
+        // the user has left for the day.
+        const token = localStorage.getItem("token");
+        try 
+        {
+          const limitRes = await api.get(
+            "/api/code/canSubmit",
+            token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
+          );
+          setProgSubmitsRemaining(limitRes.data.remaining);
+        } 
+        catch 
+        {
+          // Just set the questions normally
+        }
+        
         setProblems(withOptions);
       } 
       catch (error: unknown)
@@ -264,7 +287,8 @@ const TopicTestPage: React.FC = () => {
             ? programmingAnswer.trim().length > 0
             : selectedAnswers.length > 0;
 
-    if (!current || !hasAnswer) return;
+    if (!current || !hasAnswer || isSubmitting) return;
+    setIsSubmitting(true);
 
     if (questionType === "programming") {
       setPointsEarned(null);
@@ -277,6 +301,7 @@ const TopicTestPage: React.FC = () => {
         setFeedback("Unsupported language.");
         setIsCorrectAnswer(false);
         setAnswered(true);
+        setIsSubmitting(false);
         return;
       }
 
@@ -293,48 +318,57 @@ const TopicTestPage: React.FC = () => {
         );
 
         const data = result.data;
+
+        // Decrement remaining submits
+        // Backend counts all submits toward daily limit,
+        // regardless of correct/incorrect/error,
+        // as long as the response is a 200.
+        setProgSubmitsRemaining(prev => prev !== null ? prev - 1 : null);
+
         if (data.success) {
           // Show accepted vs incorrect based on judge response.
-          const statusText = data.correct ? "Accepted" : "Incorrect";
-          // Build optional output lines only when provided.
-          const outputText = data.stdout ? `Output: ${data.stdout}` : "Output: (none)";
-          const expectedText = data.expectedOutput ? `Expected: ${data.expectedOutput}` : "";
-          setFeedback([statusText, outputText, expectedText].filter(Boolean).join(" | "));
-          setIsCorrectAnswer(Boolean(data.correct));
+          const passed = data.passedTests ?? 0;
+          const total = data.totalTests ?? 0;
+          const label = data.allPassed ? "Correct!" : passed > 0 ? "Not quite!" : "Incorrect.";
+          setFeedback(label);
+          setIsCorrectAnswer(Boolean(data.allPassed));
+          setPointsEarned(typeof data.pointsEarned === "number" ? data.pointsEarned : null);
+          setPointsPossible(typeof data.pointsPossible === "number" ? data.pointsPossible : null);
+          setPassedTests(passed);
+          setTotalTests(total);
         } else {
-          const statusText = `Status: ${data.status || "Execution failed"}`;
           // Include compiler/runtime errors when present.
-          const stderrText = data.stderr ? `Error: ${data.stderr}` : "";
-          const compileText = data.compile_output ? `Compile: ${data.compile_output}` : "";
-          setFeedback([statusText, compileText, stderrText].filter(Boolean).join(" | "));
+          const errorDetails = data.compile_output || data.stderr || data.error || "";
+          setFeedback(`${data.status || "Execution failed"}${errorDetails ? `: ${errorDetails}` : ""}`);
           setIsCorrectAnswer(false);
+          setPassedTests(null);
+          setTotalTests(null);
         }
       } catch (error: unknown) {
-        console.error("Failed to submit programming response:", error);
-        
-        // Log the full error details for debugging
-        if (error && typeof error === 'object' && 'response' in error) {
-          // Type-cast the error to axios error shape for safe access to response properties
-          const axiosError = error as { response?: { status?: number; data?: { error?: string; message?: string }; statusText?: string } };
-          console.error("Backend response:", {
-            status: axiosError.response?.status,
-            statusText: axiosError.response?.statusText,
-            data: axiosError.response?.data,
-          });
-          
-          const errorMsg = axiosError.response?.data?.error 
-            || axiosError.response?.data?.message
-            || axiosError.response?.statusText
-            || "Unknown error";
-          setFeedback(`Failed to submit programming response (${axiosError.response?.status || 'unknown'}): ${errorMsg}`);
-        } else {
-          const errorMessage = error instanceof Error ? error.message : "Unknown error";
-          setFeedback(`Failed to submit programming response: ${errorMessage}`);
+        if (isAxiosError(error))
+        {
+          // Daily submission limit reached.
+          // This should never actually be reachable since
+          // the backend should stop serving programming questions to users
+          // once they hit the limit. But just in case.
+          if (error.response?.status === 429)
+          {
+            setFeedback("Daily programming question submission limit exceeded. Come back tomorrow!");
+          }
+          else
+          {
+            setFeedback("Submission failed. Please try again later.");
+          }
+        }
+        else
+        {
+          setFeedback("Submission failed. Please try again later.");
         }
         setIsCorrectAnswer(false);
       }
 
       setAnswered(true);
+      setIsSubmitting(false);
       return;
     }
 
@@ -349,6 +383,7 @@ const TopicTestPage: React.FC = () => {
           setFeedback("Error: Invalid answer format for drag and drop question");
           setIsCorrectAnswer(false);
           setAnswered(true);
+          setIsSubmitting(false);
           return;
         }
         
@@ -363,6 +398,7 @@ const TopicTestPage: React.FC = () => {
           setFeedback("Error: Some answer placements are invalid");
           setIsCorrectAnswer(false);
           setAnswered(true);
+          setIsSubmitting(false);
           return;
         }
       }
@@ -374,6 +410,7 @@ const TopicTestPage: React.FC = () => {
         setPointsPossible(null);
         setNormalizedScore(null);
         setAnswered(true);
+        setIsSubmitting(false);
         return;
       }
 
@@ -393,6 +430,7 @@ const TopicTestPage: React.FC = () => {
         setFeedback("Error: Unable to serialize answer data");
         setIsCorrectAnswer(false);
         setAnswered(true);
+        setIsSubmitting(false);
         return;
       }
 
@@ -418,6 +456,7 @@ const TopicTestPage: React.FC = () => {
       );
       if (isCorrect) setCorrectCount((prev) => prev + 1);
       setAnswered(true);
+      setIsSubmitting(false);
     } 
     catch (error: unknown)
     {
@@ -444,6 +483,7 @@ const TopicTestPage: React.FC = () => {
       }
       setIsCorrectAnswer(false);
       setAnswered(true);
+      setIsSubmitting(false);
     }
   };
 
@@ -460,6 +500,8 @@ const TopicTestPage: React.FC = () => {
     setPointsEarned(null);
     setPointsPossible(null);
     setNormalizedScore(null);
+    setPassedTests(null);
+    setTotalTests(null);
     if (currentIndex + 1 < problems.length) {
       setCurrentIndex((prev) => prev + 1);
     } else {
@@ -643,6 +685,16 @@ const TopicTestPage: React.FC = () => {
           setSelectedLanguage={setProgrammingLanguage}
           handleSubmit={handleSubmit}
           handleNext={handleNext}
+          answered={answered}
+          isSubmitting={isSubmitting}
+          isCorrect={isCorrectAnswer}
+          feedbackText={feedback}
+          pointsEarned={pointsEarned}
+          pointsPossible={pointsPossible}
+          normalizedScore={normalizedScore}
+          passedTests={passedTests}
+          totalTests={totalTests}
+          submissionsRemaining={progSubmitsRemaining}
         />
       ) : questionType === "select_all_that_apply" ? (
         <SelectAllThatApply


### PR DESCRIPTION
This PR addresses [SCRUM-201: Miscellaneous Programming Bugs](https://knightwise.atlassian.net/browse/SCRUM-201).

- This PR fixes several bugs introduced by the integration of the programming question frontend and backend.
- This PR also adds some tweaks to the programming question UI.

- Backend support:

  - Added base64 encoding to `judge0Service.js` to properly accept source code from the frontend.
    - This resolves **Bug 1** of the Jira story, as 502s no longer occur when bad code is submitted. They 200 as intended.
  - `codeController.js` now returns more information (points earned, test cases passed) in the case of a compilation/runtime error so that the frontend can display useful grading feedback in all use cases. This helps address **Bug 2** of the Jira story.
  - Fixed a secret **Bug 4** that wasn't in the story by explicitly inserting DATETIME into a Response in `codeController.js`.
    - In the History Table, programming questions were showing up 4 hours ahead of the actual time of completion because no DATETIME was provided during Response insertion, so it was using UTC time. See the end-to-end test below for screenshots of the fixed bug.

  - New endpoint **GET** `/api/code/canSubmit`:
    -  Checks whether the user can submit any more programming responses today.
    -  Returns a JSON object with two fields:
      - boolean **canSubmit**: true if the user has not yet reached the daily limit, false otherwise.
      - number **remaining**: the number of programming question submissions the user has left today (0 if limit reached).
    - This endpoint is used in `TopicTestPage.tsx` and `MockTestPage.tsx` to check whether a user's programming question submission is their last one of the day. If it is, a special message will be displayed to the user notifying them that they can come back tomorrow for more programming questions (screenshots in end-to-end test).

  - **[IMPORTANT]** Modified endpoint **GET** `/test/topic/{topicName}`:
    - Rather then just being a "get questions by topic" enumerator, this endpoint now serves as a "topic practice session generator".
    - We need to make sure from this point on that we _don't_ try to use this endpoint as a question enumerator. It will give incomplete information regarding the number of programming questions in a topic. I don't expect us to need an all-purpose "get question by topic endpoint" outside of topic practice generation, but if we do, we'll need to create another endpoint and rename `/test/topic/{topicName}` to something like `/test/topic/topicTest`.
    - The only actual behavior change to this endpoint is that when fetching a topic, a maximum of **one** programming question will be in the response, and **zero** will be in the response if the user has reached the max daily submission limit for programming questions.
      - The purpose behind this change is to prevent users from being given a programming question that they're unable to submit due to being at the daily submit limit. Instead of having them waste time writing code only to find out they can't submit it, now we just don't give them programming questions until the next day.
      - But then this brought up a point of confusion; if users aren't aware that they've hit the limit, they may be confused why they're suddenly not seeing any programming questions.
        - The `/api/code/canSubmit` endpoint and "come back tomorrow" message was created to combat this.

  - Modified endpoint **GET** `/test/mocktest`:
    - Same behavior modification as the above endpoint. Now this generates a mock test with a maximum of **one** programming question if the user hasn't hit their daily submit limit, or **zero** if they have.
    - However, this doesn't bring up the same design concerns as the above endpoint, since this endpoint was always designed explicitly to generate a mock test, and that's it's only possible use.

- Frontend support:
  - The programming UI now gives grading feedback on submit, showing points, test cases passed, and any error info. This addresses **Bug 2** of the Jira story.
  - The run console placeholder message was tweaked a bit to convey that source code is run against the example input.
  - Removed the dual Submit/Next buttons in favor of a Submit button that turns into a Next button (or Results button if it was the last question) like the other question types use. This resolves **Bug 3** of the Jira story.

- Integration tests were added to verify all current and new functionality.
- `swagger.yaml` documentation was updated.
- Changes were tested locally.

- Below: Proof of all test cases passing.
<img width="876" height="356" alt="image" src="https://github.com/user-attachments/assets/3cbc068d-7ee8-4d3d-b643-a306a9903f51" />

**End-to-End Test**

- Below: See new placeholder text in console.
<img width="1916" height="946" alt="image" src="https://github.com/user-attachments/assets/bdd1dc02-703b-4f9b-aafb-02c9cbb08003" />

- Below: Compilation error during test run.
<img width="1919" height="949" alt="image" src="https://github.com/user-attachments/assets/dfc5a16f-d195-4d1e-8946-974701611f43" />

- Below: Runtime error during test run.
<img width="1919" height="944" alt="image" src="https://github.com/user-attachments/assets/606835ed-771a-4040-8526-47cbb620f30f" />

- Below: Regular test run. This source code ignores the example input given to it.
<img width="1915" height="936" alt="image" src="https://github.com/user-attachments/assets/2e20c386-66a0-43d0-9377-4936dfd6d7d3" />

- Below: Regular test run. This source code uses the example input given to it.
<img width="1919" height="950" alt="image" src="https://github.com/user-attachments/assets/2bb79ad4-a459-4cb5-8c41-2f1f72709493" />

- Below: Grading feedback on submit with compilation error.
<img width="1919" height="947" alt="image" src="https://github.com/user-attachments/assets/1793086b-da3a-4577-8804-2bcd3af53939" />

- Below: Grading feedback on submit with incorrect answer.
<img width="1914" height="943" alt="image" src="https://github.com/user-attachments/assets/03372133-1460-4385-9eee-e093830eeb1f" />

- Below: Grading feedback on submit with partial credit.
<img width="1914" height="942" alt="image" src="https://github.com/user-attachments/assets/b87f3b3a-f6c7-4397-81b0-51317284ebf2" />

- Below: Same as the above screenshot but with a mock test question. The behavior should be identical between mock test programming questions and topic practice programming questions.
<img width="1919" height="948" alt="image" src="https://github.com/user-attachments/assets/41727c69-54bf-4ba1-95bc-241f540fce5a" />

- Below: Grading feedback on submit with correct answer.
<img width="1912" height="927" alt="image" src="https://github.com/user-attachments/assets/d759c4f6-6c63-4279-983a-b51f283cd66f" />

- Below: New message for test run limit exceed. No longer exposes error code info.
<img width="1919" height="949" alt="image" src="https://github.com/user-attachments/assets/a7283453-0ee6-4d6d-87fa-a65719e0579b" />

- Below: New message informing the user that this is their last submission. They won't be given any more programming questions after this in topic practice nor mock test.
<img width="1919" height="948" alt="image" src="https://github.com/user-attachments/assets/62bcc5f5-92fd-4bef-ac10-8e1b7e0cf639" />

- Below: Proof that user won't be given any programming questions if they hit the limit. See endpoint responses.
<img width="1917" height="888" alt="image" src="https://github.com/user-attachments/assets/d74375e3-3401-4873-a8f4-a06fbe05b6b7" />
<img width="1919" height="945" alt="image" src="https://github.com/user-attachments/assets/033e68fc-d2d9-414a-8072-9490ac7c2682" />

- Below: The secret **Bug 4** that caused History Table entries for programming questions to be 4 hours ahead is fixed. Now it shows the correct time.
<img width="1919" height="944" alt="image" src="https://github.com/user-attachments/assets/38a5df7b-22b4-4c67-857c-6db0fcab3927" />
<img width="1917" height="951" alt="image" src="https://github.com/user-attachments/assets/df1182b8-84ed-48a5-8a47-e1ffef2804dc" />

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-201