### PR TITLE
SCRUM-204: API/Frontend String Normalization

### DIFF
--- a/backend/controllers/gradingController.js
+++ b/backend/controllers/gradingController.js
@@ -13,6 +13,7 @@
 //                 rankedChoice grader
 //                 dragAndDrop grader
 //                 errorHandler
+//                 validationUtils
 //
 ////////////////////////////////////////////////////////////////
 
@@ -22,6 +23,7 @@ const { gradeSelectAllThatApply } = require('../services/graders/selectAllThatAp
 const { gradeRankedChoice } = require('../services/graders/rankedChoice');
 const { gradeDragAndDrop } = require('../services/graders/dragAndDrop');
 const { AppError } = require('../middleware/errorHandler');
+const { normalizeDBString } = require('../utils/validationUtils');
 
 /**
  * Grade question based on its type and calculate points earned
@@ -43,10 +45,13 @@ function gradeQuestion(questionId, questionType, userAnswer, allAnswers, pointsP
 {
   let result;  
 
+  // Prevent database inconsistencies from breaking logic
+  const normalizedType = normalizeDBString(questionType);
+
   // Some graders need all answers, others only need correct answers
   const correctAnswers = allAnswers.filter(a => a.IS_CORRECT_ANSWER);
 
-  switch (questionType) 
+  switch (normalizedType) 
   {
     case 'Multiple Choice':
       result = gradeMultipleChoice(userAnswer, allAnswers);
@@ -65,7 +70,7 @@ function gradeQuestion(questionId, questionType, userAnswer, allAnswers, pointsP
       break;
     default:
       throw new AppError(
-        `Unsupported question type "${questionType}" for question ${questionId}`,
+        `Unsupported question type "${normalizedType}" for question ${questionId}`,
         400,
         'Unsupported question type'
       );

--- a/backend/routes/myProgress.js
+++ b/backend/routes/myProgress.js
@@ -11,6 +11,7 @@
 //                 express
 //                 authMiddleware
 //                 errorHandler
+//                 validationUtils
 //
 ////////////////////////////////////////////////////////////////
 
@@ -18,6 +19,7 @@ const express = require('express');
 const router = express.Router();
 const authMiddleware = require("../middleware/authMiddleware");
 const { asyncHandler, AppError } = require("../middleware/errorHandler");
+const { normalizeDBString } = require('../utils/validationUtils');
 
 /**
  * Helper function to process answers and calculate user progress by topic
@@ -30,7 +32,8 @@ const processProgressData = (answers) => {
   const progress = {};
 
   answers.forEach((answer) => {
-    const topic = answer.TOPIC;
+    // Prevent database inconsistencies from breaking logic
+    const topic = normalizeDBString(answer.TOPIC);
     const isCorrect = answer.ISCORRECT;
 
     // Initialize topic if not already in progress
@@ -111,20 +114,30 @@ router.get("/messageData", authMiddleware, asyncHandler(async (req, res) => {
   );
 
   // Process history and mastery levels
-  const history = userAnswers.map(({ DATETIME, TOPIC }) => ({
-    datetime: DATETIME,
-    topic: TOPIC,
+  const history = userAnswers.map((row) => ({
+    datetime: row.DATETIME,
+    // Prevent database inconsistencies from breaking logic
+    topic: normalizeDBString(row.TOPIC),
   }));
 
   // Compute mastery levels
   const mastery = {};
-  userAnswers.forEach(({ TOPIC, ISCORRECT }) => {
-    if (!mastery[TOPIC]) {
-      mastery[TOPIC] = { correct: 0, total: 0 };
+  userAnswers.forEach((row) => {
+
+    // Prevent database inconsistencies from breaking logic
+    // NOTE: We call it TOPIC in the Response table,
+    // but it actually refers to the corresponding Question's
+    // SUBCATEGORY field. Really we should just remove
+    // all fields from Response that can be accessed through
+    // Question since Response has a foreign key to Question.
+    const normalizedSubcategory = normalizeDBString(row.TOPIC);
+
+    if (!mastery[normalizedSubcategory]) {
+      mastery[normalizedSubcategory] = { correct: 0, total: 0 };
     }
-    mastery[TOPIC].total += 1;
-    if (ISCORRECT) {
-      mastery[TOPIC].correct += 1;
+    mastery[normalizedSubcategory].total += 1;
+    if (row.ISCORRECT) {
+      mastery[normalizedSubcategory].correct += 1;
     }
   });
 
@@ -218,7 +231,8 @@ router.get('/history', authMiddleware, asyncHandler(async (req, res) => {
   res.status(200).json({
     history: history.map(row => ({
       datetime:       row.DATETIME,
-      topic:          row.TOPIC,
+      // Prevent database inconsistencies from breaking logic
+      topic:          normalizeDBString(row.TOPIC),
       type:           row.TYPE,
       isCorrect:      row.ISCORRECT,
       problem_id:     row.PROBLEM_ID,

--- a/backend/utils/validationUtils.js
+++ b/backend/utils/validationUtils.js
@@ -15,6 +15,29 @@
 const { AppError } = require('../middleware/errorHandler');
 
 /**
+ * Normalizes a database string (Heaps, Multiple Choice, etc.),
+ * removing carriage return and newline escape chars
+ * with a global replace. 
+ * 
+ * The eventual goal is to no longer need this and have
+ * the database provide consistent data through enums.
+ * 
+ * NOTE: Unlike the frontend's formatSubcategoryLabel(),
+ *       which turns the canonical InputOutput subcategory
+ *       to the displayed Input/Output from API -> frontend, 
+ *       this function does the reverse, turning
+ *       Input/Output to InputOutput on database -> API,
+ *       because some legacy data still has Input/Output when
+ *       it should have InputOutput.
+ * 
+ * @param   {string} str - Raw string from database
+ * @returns {string} Normalized string
+ */
+const normalizeDBString = (str) => {
+  return str.replace(/\r\n|\r|\n/g, ' ').trim().replace('Input/Output', 'InputOutput');
+}
+
+/**
  * Parses and validates a user ID from a route parameter
  * 
  * @param {string} rawId       - Raw route parameter (req.params.id)
@@ -57,4 +80,5 @@ const validateName = (name) => {
 module.exports = {
   parseUserId,
   validateName,
+  normalizeDBString,
 }

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -11,6 +11,7 @@
 //                 react-router-dom
 //                 api instance
 //                 models
+//                 topicLabels
 //
 ////////////////////////////////////////////////////////////////
 
@@ -21,6 +22,7 @@ import api from "../api";
 import { HistoryEntry, UserInfoResponse } from "../models";
 import { useUserCustomizationStore, userCustomizationStore } from "../stores/userCustomizationStore";
 import { getBackgroundUrlByItemName } from "../utils/storeCosmetics";
+import { ALL_TOPICS, formatSubcategoryLabel } from "../utils/topicLabels";
 
 interface MessageDataResponse {
   history?: Array<{ datetime: string; topic: string }>;
@@ -43,47 +45,13 @@ const DAILY_GOAL_QUESTIONS = 10;
 const DAILY_GOAL_FIRE_MULTIPLIER = 2;
 const DAILY_GOAL_GOOUTSIDE_MULTIPLIER = 3;
 
-const VALID_TOPIC_SLUGS = new Set([
-  "InputOutput",
-  "Branching",
-  "Loops",
-  "Variables",
-  "Arrays",
-  "Linked Lists",
-  "Strings",
-  "Classes",
-  "Methods",
-  "Trees",
-  "Stacks",
-  "Heaps",
-  "Tries",
-  "Bitwise Operators",
-  "Dynamic Memory",
-  "Algorithm Analysis",
-  "Recursion",
-  "Sorting",
-]);
-
 const toCanonicalTopicSlug = (topic?: string): string | null => {
   const value = String(topic || "").trim();
   if (!value) {
     return null;
   }
-
   const normalized = value === "Input/Output" ? "InputOutput" : value;
-  return VALID_TOPIC_SLUGS.has(normalized) ? normalized : null;
-};
-
-const formatTopicLabel = (topic?: string): string => {
-  const normalized = toCanonicalTopicSlug(topic);
-  if (!normalized) {
-    return String(topic || "").trim();
-  }
-  return normalized === "InputOutput" ? "Input/Output" : normalized;
-};
-
-const toTopicSlug = (topic?: string): string => {
-  return toCanonicalTopicSlug(topic) || "";
+  return (ALL_TOPICS as readonly string[]).includes(normalized) ? normalized : null;
 };
 
 const getStoredUserId = (): number | null => {
@@ -254,7 +222,7 @@ const Dashboard: React.FC = () => {
   const todayEntries = useMemo(() => {
     return recentHistory.filter((entry) => new Date(entry.datetime).toDateString() === todayKey);
   }, [recentHistory, todayKey]);
-  
+
   const correctTodayEntries = useMemo(() => {
     return todayEntries.filter((entry) => Boolean(entry.isCorrect));
   }, [todayEntries]);
@@ -349,11 +317,11 @@ const Dashboard: React.FC = () => {
 
   const lastAttempt = recentHistory[0] || null;
   const lastTopicSlug = toCanonicalTopicSlug(lastAttempt?.topic);
-  const lastTopicLabel = formatTopicLabel(lastTopicSlug || lastAttempt?.topic);
-  const weakTopicLabel = weakestTopics.length > 0 ? formatTopicLabel(weakestTopics[0][0]) : null;
+  const lastTopicLabel = formatSubcategoryLabel(lastTopicSlug || lastAttempt?.topic);
+  const weakTopicLabel = weakestTopics.length > 0 ? formatSubcategoryLabel(weakestTopics[0][0]) : null;
 
   const handlePracticeTopic = (topic: string) => {
-    const slug = toTopicSlug(topic);
+    const slug = toCanonicalTopicSlug(topic);
     if (!slug) {
       navigate("/topic-practice");
       return;
@@ -517,7 +485,7 @@ const Dashboard: React.FC = () => {
                 {weakestTopics.map(([topic, score]) => (
                   <div key={topic} className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 bg-gray-50">
                     <div>
-                      <p className="font-semibold text-gray-900">{formatTopicLabel(topic)}</p>
+                      <p className="font-semibold text-gray-900">{formatSubcategoryLabel(topic)}</p>
                       <p className="text-xs text-gray-500">Mastery: {Math.round(score)}%</p>
                     </div>
                     <button

--- a/frontend/src/components/Graph.tsx
+++ b/frontend/src/components/Graph.tsx
@@ -11,6 +11,7 @@
 //                 chart.js
 //                 api instance
 //                 models (ProgressData)
+//                 topicLabels
 //
 ////////////////////////////////////////////////////////////////
 
@@ -29,33 +30,13 @@ import {
 } from "chart.js";
 import api from "../api";
 import { ProgressData } from '../models';
+import { ALL_TOPICS, formatSubcategoryLabel } from '../utils/topicLabels';
 
 // Register required chart elements
 ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
 
 const Graph: React.FC = () => {
   const [progressData, setProgressData] = useState<ProgressData>({});
-  
-  const allTopics = [
-    "Input/Output",
-    "Branching",
-    "Loops",
-    "Variables",
-    "Arrays",
-    "Linked Lists",
-    "Strings",
-    "Classes",
-    "Methods",
-    "Trees",
-    "Stacks",
-    "Heaps",
-    "Tries",
-    "Bitwise Operators",
-    "Dynamic Memory",
-    "Algorithm Analysis",
-    "Recursion",
-    "Sorting"
-  ];
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -84,11 +65,11 @@ const Graph: React.FC = () => {
 
   // Prepare radar chart data
   const chartData = {
-    labels: allTopics,
+    labels: ALL_TOPICS.map(topic => formatSubcategoryLabel(topic)),
     datasets: [
       {
         label: "Mastery Level",
-        data: allTopics.map(topic => {
+        data: ALL_TOPICS.map(topic => {
           // Set the mastery level (percentage) for each topic
           const topicData = progressData[topic];
           if (topicData !== undefined && topicData.percentage !== undefined) {

--- a/frontend/src/components/HistoryTable.tsx
+++ b/frontend/src/components/HistoryTable.tsx
@@ -9,7 +9,7 @@
 //  Dependencies:  react
 //                 api instance
 //                 models (RawQuestion, HistoryEntry, HistoryResponse)
-//                 
+//                 topicLabels
 //
 ////////////////////////////////////////////////////////////////
 
@@ -19,6 +19,7 @@ import correctAnswerImg from "../assets/correctAnswer.png";
 import incorrectAnswerImg from "../assets/incorrectAnswer.png";
 import viewProblemImg from "../assets/viewProblem.png";
 import { RawQuestion, HistoryEntry, HistoryResponse } from '../models';
+import { formatSubcategoryLabel } from '../utils/topicLabels';
 
 const HistoryTable: React.FC = () => {
   const [history, setHistory]         = useState<HistoryEntry[]>([]);
@@ -93,7 +94,7 @@ const HistoryTable: React.FC = () => {
         // Question data
         questionText: problem.QUESTION_TEXT,
         category:     problem.CATEGORY,
-        topic:        problem.SUBCATEGORY,
+        topic:        formatSubcategoryLabel(problem.SUBCATEGORY),
         type:         problem.TYPE,
         answers:      problem.answers ?? [],
 
@@ -150,7 +151,7 @@ const HistoryTable: React.FC = () => {
                     minute: '2-digit',
                   })}
                   </td>
-                  <td className="px-4 py-2 text-center">{entry.topic}</td>
+                  <td className="px-4 py-2 text-center">{formatSubcategoryLabel(entry.topic)}</td>
                   <td className="px-4 py-2 text-center whitespace-nowrap">{entry.type ?? '—'}</td>
                   <td className="px-4 py-2 text-center">
                     <img

--- a/frontend/src/components/MockTestInfo.tsx
+++ b/frontend/src/components/MockTestInfo.tsx
@@ -1,4 +1,18 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     KnightWise Team
+//  File:          MockTestInfo.tsx
+//  Description:   "Build an Exam" setup page component
+//
+//  Dependencies:  react
+//                 topicLabels
+//
+////////////////////////////////////////////////////////////////
+
 import React from "react";
+import { formatSubcategoryLabel } from "../utils/topicLabels";
 
 interface MockTestInfoProps {
   availableTopics: string[];
@@ -87,7 +101,7 @@ const MockTestInfo: React.FC<MockTestInfoProps> = ({
                     aria-pressed={isSelected}
                   >
                     <div className="flex items-center justify-between gap-4">
-                      <span className="text-sm font-semibold sm:text-base">{topic}</span>
+                      <span className="text-sm font-semibold sm:text-base">{formatSubcategoryLabel(topic)}</span>
                       <span
                         className={[
                           "inline-flex h-5 w-5 items-center justify-center rounded-full border text-xs font-bold",

--- a/frontend/src/components/ProgressMessage.tsx
+++ b/frontend/src/components/ProgressMessage.tsx
@@ -7,37 +7,18 @@
 //  Description:   Progress tab message component.
 //
 //  Dependencies:  react
+//                 topicLabels
 //
 ////////////////////////////////////////////////////////////////
 
 import React from "react";
+import { ALL_TOPICS, formatSubcategoryLabel } from "../utils/topicLabels";
 
 interface ProgressMessageProps {
   history: { datetime: string; topic: string }[];
   mastery: { [topic: string]: number };
   streakCount: number;
 }
-
-const allTopics = [
-  "Input/Output",
-  "Branching",
-  "Loops",
-  "Variables",
-  "Arrays",
-  "Linked Lists",
-  "Strings",
-  "Classes",
-  "Methods",
-  "Trees",
-  "Stacks",
-  "Heaps",
-  "Tries",
-  "Bitwise Operators",
-  "Dynamic Memory",
-  "Algorithm Analysis",
-  "Recursion",
-  "Sorting"
-];
 
 const ProgressMessage: React.FC<ProgressMessageProps> = ({ history, mastery, streakCount }) => {
   const today = new Date().toDateString();
@@ -57,7 +38,7 @@ const ProgressMessage: React.FC<ProgressMessageProps> = ({ history, mastery, str
     : null;
 
   // Find an unattempted topic
-  const unattemptedTopics = allTopics.filter((topic) => !(topic in mastery));
+  const unattemptedTopics = ALL_TOPICS.filter((topic) => !(topic in mastery));
   const unattemptedTopic = unattemptedTopics.length > 0 ? unattemptedTopics[0] : null;
 
   return (
@@ -73,14 +54,14 @@ const ProgressMessage: React.FC<ProgressMessageProps> = ({ history, mastery, str
 
       {weakestTopic && (
         <span>
-          A little extra practice on <strong>{weakestTopic}</strong> will help
+          A little extra practice on <strong>{formatSubcategoryLabel(weakestTopic)}</strong> will help
           solidify your skills!&nbsp;
         </span>
       )}
 
       {unattemptedTopic && (
         <span>
-          Want to branch out? Try <strong>{unattemptedTopic}</strong> next!&nbsp;
+          Want to branch out? Try <strong>{formatSubcategoryLabel(unattemptedTopic)}</strong> next!&nbsp;
         </span>
       )}
 

--- a/frontend/src/pages/MockTestPage.tsx
+++ b/frontend/src/pages/MockTestPage.tsx
@@ -15,6 +15,7 @@
 //                 MockTestResult component
 //                 models (Question, MockTestResponse)
 //                 axios (isAxiosError)
+//                 topicLabels
 //
 ////////////////////////////////////////////////////////////////
 
@@ -31,29 +32,9 @@ import Programming from "../components/Programming";
 import api from "../api";
 import { Question, RawQuestion } from "../models";
 import { isAxiosError } from "axios";
+import { ALL_TOPICS } from "../utils/topicLabels";
 
-const AVAILABLE_TOPICS = [
-  "Input/Output",
-  "Branching",
-  "Loops",
-  "Variables",
-  "Arrays",
-  "Linked Lists",
-  "Strings",
-  "Classes",
-  "Methods",
-  "Trees",
-  "Stacks",
-  "Heaps",
-  "Tries",
-  "Bitwise Operators",
-  "Dynamic Memory",
-  "Algorithm Analysis",
-  "Recursion",
-  "Sorting",
-];
-
-const DEFAULT_SELECTED_TOPICS = ["Input/Output", "Branching", "Loops", "Variables"];
+const DEFAULT_SELECTED_TOPICS = ["InputOutput", "Branching", "Loops", "Variables"];
 const DEFAULT_QUESTION_COUNT = 12;
 const MIN_QUESTION_COUNT = 1;
 const MAX_QUESTION_COUNT = 50;
@@ -621,7 +602,7 @@ const MockTestPage: React.FC = () => {
     <Layout>
       {step === "info" && (
         <MockTestInfo
-          availableTopics={AVAILABLE_TOPICS}
+          availableTopics={[...ALL_TOPICS]}
           selectedTopics={selectedTopics}
           questionCount={questionCount}
           timeLimitMinutes={timeLimitMinutes}
@@ -630,7 +611,7 @@ const MockTestPage: React.FC = () => {
           onToggleTopic={handleToggleTopic}
           onSelectAll={() => {
             setSetupError("");
-            setSelectedTopics(AVAILABLE_TOPICS);
+            setSelectedTopics([...ALL_TOPICS]);
           }}
           onClearAll={() => {
             setSetupError("");

--- a/frontend/src/utils/topicLabels.ts
+++ b/frontend/src/utils/topicLabels.ts
@@ -1,3 +1,38 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     KnightWise Team
+//  File:          topicLabels.ts
+//  Description:   Contains topic label constants and
+//                 helpers for topic label displaying.
+//
+////////////////////////////////////////////////////////////////
+
+// This is used in matching data received from the API,
+// so canonical names (InputOutput) must be used.
+// When displaying, use formatSubcategoryLabel().
+export const ALL_TOPICS = [
+  "InputOutput", // Canonical name, display name is Input/Output
+  "Branching",
+  "Loops",
+  "Variables",
+  "Arrays",
+  "Linked Lists",
+  "Strings",
+  "Classes",
+  "Methods",
+  "Trees",
+  "Stacks",
+  "Heaps",
+  "Tries",
+  "Bitwise Operators",
+  "Dynamic Memory",
+  "Algorithm Analysis",
+  "Recursion",
+  "Sorting",
+] as const;
+
 export const formatSubcategoryLabel = (subcategory?: string): string => {
   const value = String(subcategory || "").trim();
   if (!value) {


### PR DESCRIPTION
This PR addresses [SCRUM-204: InputOutput in History Table](https://knightwise.atlassian.net/browse/SCRUM-201).
- Originally this task was to format the subcategory label InputOutput in the frontend History Table so it displays Input/Output instead, but the work revealed a slew of other hidden problems related to string normalization.

**Backend support:**
- Added `normalizeDBString()` to `backend/utils/validationUtils.js`.
  - This normalizes strings from the database by removing whitespace, newlines and carriage returns.
  - This also converts legacy Input/Output entries (in Response) to InputOutput for use in the API.
  - Once the database utilizes enums for string fields this should no longer be necessary, but can be kept in as a redundancy.
- `gradingController` now normalizes question type. This fixes the bug of some problems having the type 'Multiple Choice\n' resulting in failed question fetching.
- `myProgress.js` endpoints now normalize subcategory. This fixes the bug of duplicate subcategories being logged by the endpoint resulting in inaccurate progress info.

**Frontend support:**
- Consolidated the many instances of "topic label arrays" throughout the frontend into a single source of truth in `topicLabels.ts`.
  - It's important to note that this read-only array stores the *canonical* names for topics since the topic names are used to interact with the API, which don't recognize the display names (Input/Output). So whenever a name from this list is rendered to the frontend, it's important to use the existing `formatSubcategoryLabel()` function, otherwise Input/Output will be shown as its InputOutput canonical form.

- Changes were tested locally.

- Below: Proof of all current tests still passing.
<img width="891" height="368" alt="image" src="https://github.com/user-attachments/assets/1a6e3918-5055-4e7b-8ed3-448461b936e6" />

- Below: History Table now accurately shows display name instead of canonical name for InputOutput.
<img width="1161" height="770" alt="image" src="https://github.com/user-attachments/assets/dde08bd5-10ff-4458-a633-da4bb2602123" />
<img width="936" height="893" alt="image" src="https://github.com/user-attachments/assets/161368b3-b742-43e1-a3ec-6f45549d835f" />

- Below: Progress graph and progress message shows display name. This was done on a new account so I could get Input/Output as my weakest topic.
<img width="1428" height="793" alt="image" src="https://github.com/user-attachments/assets/a7dc21ce-d9d9-4fb6-9113-474ca4a86328" />

- Below: Dashboard still properly shows display name for InputOutput. (The first screenshot was done in a new account to show Input/Output in weakest topics.)
<img width="1408" height="810" alt="image" src="https://github.com/user-attachments/assets/492f4a8b-af74-4b55-afdf-e4481f315a4f" />
<img width="1399" height="830" alt="image" src="https://github.com/user-attachments/assets/084dff9b-4821-4367-a6ea-c5b4d40198ec" />

- Below: "Build an Exam" page still properly shows display name for InputOutput.
<img width="1443" height="826" alt="image" src="https://github.com/user-attachments/assets/0bc23737-64b1-437b-b824-99cf510f8c8f" />

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-201