### PR TITLE
SCRUM-178: API for Guilds and Analytics Engine #large

### DIFF
--- a/backend/__test__/code.test.js
+++ b/backend/__test__/code.test.js
@@ -10,7 +10,6 @@
 //                 mysql2 connection pool (server.js)
 //                 judge0Service
 //                 testHelpers
-//                 discordWebhook (mocked)
 //                 codeLimits
 //                 errorHandler
 //
@@ -22,13 +21,6 @@ const judge0Service = require('../services/judge0Service');
 const { TEST_USER, getAuthToken, verifyTestDatabase } = require("./testHelpers");
 const { MAX_CODE_BYTES, MAX_SUBMISSIONS_PER_DAY, MAX_TEST_RUNS_PER_PROBLEM } = require('../config/codeLimits'); 
 const { AppError } = require('../middleware/errorHandler');
-
-// Mock Discord webhook
-jest.mock('../services/discordWebhook', () => ({
-  sendNotification: jest.fn().mockResolvedValue(true),
-  notifyUserEvent: jest.fn().mockResolvedValue(true),
-  notifyError: jest.fn().mockResolvedValue(true),
-}));
 
 // Mock Judge0 service
 jest.mock('../services/judge0Service', () => {

--- a/backend/__test__/currencyUtils.test.js
+++ b/backend/__test__/currencyUtils.test.js
@@ -1,0 +1,130 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          currencyUtils.test.js
+//  Description:   Unit tests for guild exp contribution:
+//                 awardGuildExp()
+//
+//                 Note: awardCurrency() is covered by test.test.js
+//                 Daily EXP Cap Tests. Tests here focus on
+//                 guild-specific passive exp behavior.
+//
+//  Dependencies:  mysql2 connection pool (server.js)
+//                 testHelpers
+//                 currencyConfig
+//                 guildConfig
+//
+////////////////////////////////////////////////////////////////
+
+const { pool } = require('../server');
+const {
+        TEST_USER,
+        verifyTestDatabase,
+        getAuthToken,
+        insertUser,
+        insertGuildWithOwner,
+        insertGuildMember,
+      } = require('./testHelpers');
+const { awardGuildExp } = require('../utils/currencyUtils');
+const { EXP_PER_POINT } = require('../../shared/currencyConfig');
+const { GUILD_EXP_CONTRIBUTION_RATIO } = require('../../shared/guildConfig');
+
+let userId;
+
+beforeAll(async () => {
+  await verifyTestDatabase(pool);
+  await pool.query('DELETE FROM User');
+  await pool.query('DELETE FROM Guild');
+
+  await getAuthToken();
+  const [rows] = await pool.query('SELECT ID FROM User WHERE EMAIL = ?', [TEST_USER.email]);
+  userId = rows[0].ID;
+});
+
+beforeEach(async () => {
+  await pool.query(
+    'UPDATE User SET COINS = 0, DAILY_EXP = 0, WEEKLY_EXP = 0, LIFETIME_EXP = 0 WHERE ID = ?',
+    [userId]
+  );
+  await pool.query('DELETE FROM Guild');
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM User');
+  try { await pool.end(); }
+  catch (err) { console.error('Error closing pool in currencyUtils.test.js:', err); }
+});
+
+describe('awardGuildExp', () => {
+
+  test('adds exp to all three guild exp banks when user is a member', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Exp Guild' });
+
+    await awardGuildExp(pool, userId, 10);
+
+    const [[guild]] = await pool.query(
+      'SELECT DAILY_EXP, WEEKLY_EXP, LIFETIME_EXP FROM Guild WHERE ID = ?',
+      [guildId]
+    );
+
+    const expectedGuildExp = 10 * EXP_PER_POINT * GUILD_EXP_CONTRIBUTION_RATIO;
+    expect(guild.DAILY_EXP).toBeCloseTo(expectedGuildExp);
+    expect(guild.WEEKLY_EXP).toBeCloseTo(expectedGuildExp);
+    expect(guild.LIFETIME_EXP).toBeCloseTo(expectedGuildExp);
+  });
+
+  test('does not decrement user exp', async () => {
+    await pool.query(
+      'UPDATE User SET DAILY_EXP = 100, WEEKLY_EXP = 100, LIFETIME_EXP = 100 WHERE ID = ?',
+      [userId]
+    );
+    await insertGuildWithOwner(userId, { name: 'No Decrement Guild' });
+
+    await awardGuildExp(pool, userId, 10);
+
+    const [[user]] = await pool.query(
+      'SELECT DAILY_EXP, WEEKLY_EXP, LIFETIME_EXP FROM User WHERE ID = ?',
+      [userId]
+    );
+
+    expect(user.DAILY_EXP).toBe(100);
+    expect(user.WEEKLY_EXP).toBe(100);
+    expect(user.LIFETIME_EXP).toBe(100);
+  });
+
+  test('no-ops silently when user is not in a guild', async () => {
+    // No guild exists after beforeEach cleanup, should not throw
+    await expect(awardGuildExp(pool, userId, 10)).resolves.not.toThrow();
+  });
+
+  test('no-ops when points earned is zero', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Zero Points Guild' });
+
+    await awardGuildExp(pool, userId, 0);
+
+    const [[guild]] = await pool.query(
+      'SELECT DAILY_EXP FROM Guild WHERE ID = ?',
+      [guildId]
+    );
+
+    expect(guild.DAILY_EXP).toBe(0);
+  });
+
+  test('awards to correct guild when user is a non-owner member', async () => {
+    const ownerId = await insertUser({ username: 'gexp_owner', email: 'gexp_owner@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Member Exp Guild' });
+    await insertGuildMember(userId, guildId, 'Member');
+
+    await awardGuildExp(pool, userId, 5);
+
+    const [[guild]] = await pool.query(
+      'SELECT WEEKLY_EXP FROM Guild WHERE ID = ?',
+      [guildId]
+    );
+
+    const expectedGuildExp = 5 * EXP_PER_POINT * GUILD_EXP_CONTRIBUTION_RATIO;
+    expect(guild.WEEKLY_EXP).toBeCloseTo(expectedGuildExp);
+  });
+});

--- a/backend/__test__/guildTests/guild.test.js
+++ b/backend/__test__/guildTests/guild.test.js
@@ -1,0 +1,970 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          guild.test.js
+//  Description:   Integration tests for guild core operations:
+//                 POST   /api/guilds
+//                 DELETE /api/guilds/:id
+//                 GET    /api/guilds/:id
+//                 POST   /api/guilds/:id/contribute
+//                 DELETE /api/guilds/:id/members/:userId
+//                 PATCH  /api/guilds/:id/members/:userId/role
+//                 PUT    /api/guilds/:id/equip
+//                 PUT    /api/guilds/:id/unequip
+//
+//  Dependencies:  supertest
+//                 mysql2 connection pool (server.js)
+//                 testHelpers
+//                 discordWebhook (mocked)
+//
+////////////////////////////////////////////////////////////////
+
+const request = require('supertest');
+const { app, pool } = require('../../server');
+const {
+        TEST_USER,
+        verifyTestDatabase,
+        getAuthToken,
+        insertUser,
+        insertGuildWithOwner,
+        insertGuildMember,
+      } = require('../testHelpers');
+
+// Mock Discord webhook
+const { notifyUserEvent } = require('../../services/discordWebhook');
+jest.mock('../../services/discordWebhook', () => ({
+  sendNotification: jest.fn().mockResolvedValue(true),
+  notifyUserEvent:  jest.fn().mockResolvedValue(true),
+  notifyError:      jest.fn().mockResolvedValue(true),
+}));
+
+let token;
+let userId;
+
+beforeAll(async () => {
+  await verifyTestDatabase(pool);
+  await pool.query('DELETE FROM User');
+
+  token  = await getAuthToken();
+  const [rows] = await pool.query('SELECT ID FROM User WHERE EMAIL = ?', [TEST_USER.email]);
+  userId = rows[0].ID;
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  // Clean guild state between tests
+  await pool.query('DELETE FROM Guild');
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM User');
+  try { await pool.end(); }
+  catch (err) { console.error('Error closing pool in guild.test.js:', err); }
+});
+
+// Test guild creation
+describe('POST /api/guilds', () => {
+
+  test('201 - successfully creates guild and inserts owner as member', async () => {
+    const res = await request(app)
+      .post('/api/guilds')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Ancient Wolves' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('guildId');
+
+    // Verify guild row exists
+    const [guilds] = await pool.query('SELECT * FROM Guild WHERE ID = ?', [res.body.guildId]);
+    expect(guilds).toHaveLength(1);
+    expect(guilds[0].NAME).toBe('Ancient Wolves');
+
+    // Verify owner member row exists
+    const [members] = await pool.query(
+      'SELECT ROLE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+      [userId, res.body.guildId]
+    );
+    expect(members).toHaveLength(1);
+    expect(members[0].ROLE).toBe('Owner');
+  });
+
+  test('notifies Discord on guild creation', async () => {
+    const res = await request(app)
+      .post('/api/guilds')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Webhook Guild' });
+
+    expect(res.status).toBe(201);
+    expect(notifyUserEvent).toHaveBeenCalledTimes(1);
+    expect(notifyUserEvent).toHaveBeenCalledWith(
+      expect.stringContaining('Guild created')
+    );
+  });
+
+  test('400 - missing guild name', async () => {
+    const res = await request(app)
+      .post('/api/guilds')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  test('400 - empty guild name', async () => {
+    const res = await request(app)
+      .post('/api/guilds')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: '   ' });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('409 - user already in a guild', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'First Guild' });
+
+    const res = await request(app)
+      .post('/api/guilds')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Second Guild' });
+
+    expect(res.status).toBe(409);
+  });
+
+  test('409 - guild name already taken', async () => {
+    const otherId = await insertUser({ username: 'otherown', email: 'otherown@test.com' });
+    await insertGuildWithOwner(otherId, { name: 'Taken Name' });
+
+    const res = await request(app)
+      .post('/api/guilds')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Taken Name' });
+
+    expect(res.status).toBe(409);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .post('/api/guilds')
+      .send({ name: 'Test Guild' });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test guild deletion
+describe('DELETE /api/guilds/:id', () => {
+
+  test('200 - owner can delete their guild', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Doomed Guild' });
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    const [guilds] = await pool.query('SELECT ID FROM Guild WHERE ID = ?', [guildId]);
+    expect(guilds).toHaveLength(0);
+  });
+
+  test('notifies Discord on guild deletion', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Webhook Delete Guild' });
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(notifyUserEvent).toHaveBeenCalledTimes(1);
+    expect(notifyUserEvent).toHaveBeenCalledWith(
+      expect.stringContaining('Guild deleted')
+    );
+  });
+
+  test('403 - officer cannot delete guild', async () => {
+    const ownerId = await insertUser({ username: 'guildowner', email: 'guildowner@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Sturdy Guild' });
+    await insertGuildMember(userId, guildId, 'Officer');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('403 - member cannot delete guild', async () => {
+    const ownerId = await insertUser({ username: 'guildowner2', email: 'guildowner2@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Sturdy Guild 2' });
+    await insertGuildMember(userId, guildId, 'Member');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('400 - invalid guild ID', async () => {
+    const res = await request(app)
+      .delete('/api/guilds/abc')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  test('404 - guild not found', async () => {
+    const res = await request(app)
+      .delete('/api/guilds/999999')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Ghost Guild' });
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test fetching guild info
+describe('GET /api/guilds/:id', () => {
+
+  test('200 - returns guild info and equipped items', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Info Guild' });
+
+    const res = await request(app)
+      .get(`/api/guilds/${guildId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('guild');
+    expect(res.body).toHaveProperty('equippedItems');
+    expect(res.body.guild).toHaveProperty('ID', guildId);
+    expect(res.body.guild).toHaveProperty('NAME', 'Info Guild');
+    expect(Array.isArray(res.body.equippedItems)).toBe(true);
+  });
+
+  test('200 - equippedItems is empty when nothing equipped', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Empty Guild' });
+
+    const res = await request(app)
+      .get(`/api/guilds/${guildId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.equippedItems).toHaveLength(0);
+  });
+
+  test('400 - invalid guild ID', async () => {
+    const res = await request(app)
+      .get('/api/guilds/abc')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  test('404 - guild not found', async () => {
+    const res = await request(app)
+      .get('/api/guilds/999999')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Secret Guild' });
+
+    const res = await request(app)
+      .get(`/api/guilds/${guildId}`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test user coin contribution to guild
+describe('POST /api/guilds/:id/contribute', () => {
+
+  test('200 - member can contribute coins', async () => {
+    await pool.query('UPDATE User SET COINS = 500 WHERE ID = ?', [userId]);
+    const guildId = await insertGuildWithOwner(userId, { name: 'Rich Guild' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/contribute`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('coinBank');
+    expect(res.body).toHaveProperty('newlyUnlocked');
+
+    // Verify user coins decremented
+    const [[user]] = await pool.query('SELECT COINS FROM User WHERE ID = ?', [userId]);
+    expect(user.COINS).toBe(400);
+
+    // Verify guild bank incremented
+    const [[guild]] = await pool.query('SELECT COINS FROM Guild WHERE ID = ?', [guildId]);
+    expect(guild.COINS).toBe(100);
+  });
+
+  test('200 - auto-unlocks items when threshold met', async () => {
+    await pool.query('UPDATE User SET COINS = 1000 WHERE ID = ?', [userId]);
+    const guildId = await insertGuildWithOwner(userId, { name: 'Unlock Guild' });
+
+    // Insert a guild item with cost 100
+    const [itemResult] = await pool.query(
+      'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, 1)',
+      ['flair', 100, 'Guild Flair']
+    );
+    const itemId = itemResult.insertId;
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/contribute`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.newlyUnlocked).toHaveLength(1);
+    expect(res.body.newlyUnlocked[0]).toHaveProperty('id', itemId);
+
+    // Verify GuildUnlock row created
+    const [unlocks] = await pool.query(
+      'SELECT * FROM GuildUnlock WHERE GUILD_ID = ? AND ITEM_ID = ?',
+      [guildId, itemId]
+    );
+    expect(unlocks).toHaveLength(1);
+
+    await pool.query('DELETE FROM StoreItem WHERE ID = ?', [itemId]);
+  });
+
+  test('200 - does not re-unlock already unlocked items', async () => {
+    await pool.query('UPDATE User SET COINS = 1000 WHERE ID = ?', [userId]);
+    const guildId = await insertGuildWithOwner(userId, { name: 'Double Unlock Guild' });
+
+    const [itemResult] = await pool.query(
+      'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, 1)',
+      ['flair', 50, 'Already Unlocked Flair']
+    );
+    const itemId = itemResult.insertId;
+
+    // Pre-unlock the item
+    await pool.query(
+      'INSERT INTO GuildUnlock (GUILD_ID, ITEM_ID, IS_EQUIPPED) VALUES (?, ?, 0)',
+      [guildId, itemId]
+    );
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/contribute`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.newlyUnlocked).toHaveLength(0);
+
+    await pool.query('DELETE FROM StoreItem WHERE ID = ?', [itemId]);
+  });
+
+  test('400 - insufficient coins', async () => {
+    await pool.query('UPDATE User SET COINS = 10 WHERE ID = ?', [userId]);
+    const guildId = await insertGuildWithOwner(userId, { name: 'Poor Guild' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/contribute`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('400 - invalid amount', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Amount Guild' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/contribute`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: -50 });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('403 - non-member cannot contribute', async () => {
+    const ownerId = await insertUser({ username: 'contrib_owner', email: 'contrib_owner@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Other Guild' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/contribute`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: 10 });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('401 - no auth token', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Token Guild' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/contribute`)
+      .send({ amount: 10 });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test kicking users from guild
+describe('DELETE /api/guilds/:id/members/:userId', () => {
+
+  test('200 - owner can kick a member', async () => {
+    const guildId  = await insertGuildWithOwner(userId, { name: 'Kick Guild' });
+    const memberId = await insertUser({ username: 'kickme', email: 'kickme@test.com' });
+    await insertGuildMember(memberId, guildId, 'Member');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/members/${memberId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    const [rows] = await pool.query(
+      'SELECT * FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+      [memberId, guildId]
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test('200 - owner can kick an officer', async () => {
+    const guildId    = await insertGuildWithOwner(userId, { name: 'Kick Officer Guild' });
+    const officerId  = await insertUser({ username: 'kickofficer', email: 'kickofficer@test.com' });
+    await insertGuildMember(officerId, guildId, 'Officer');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/members/${officerId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('200 - officer can kick a member', async () => {
+    const ownerId   = await insertUser({ username: 'kickown', email: 'kickown@test.com' });
+    const guildId   = await insertGuildWithOwner(ownerId, { name: 'Officer Kick Guild' });
+    const officerId = userId;
+    await insertGuildMember(officerId, guildId, 'Officer');
+    const memberId  = await insertUser({ username: 'offkickme', email: 'offkickme@test.com' });
+    await insertGuildMember(memberId, guildId, 'Member');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/members/${memberId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('400 - owner cannot kick themselves', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Self Kick Guild' });
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/members/${userId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  test('403 - officer cannot kick another officer', async () => {
+    const ownerId    = await insertUser({ username: 'offkickown', email: 'offkickown@test.com' });
+    const guildId    = await insertGuildWithOwner(ownerId, { name: 'Officer vs Officer Guild' });
+    await insertGuildMember(userId, guildId, 'Officer');
+    const officer2Id = await insertUser({ username: 'officer2', email: 'officer2@test.com' });
+    await insertGuildMember(officer2Id, guildId, 'Officer');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/members/${officer2Id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('403 - member cannot kick anyone', async () => {
+    const ownerId   = await insertUser({ username: 'memkickown', email: 'memkickown@test.com' });
+    const guildId   = await insertGuildWithOwner(ownerId, { name: 'Member Kick Guild' });
+    await insertGuildMember(userId, guildId, 'Member');
+    const target    = await insertUser({ username: 'memkicktgt', email: 'memkicktgt@test.com' });
+    await insertGuildMember(target, guildId, 'Member');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/members/${target}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('404 - target not a member', async () => {
+    const guildId    = await insertGuildWithOwner(userId, { name: 'Not Member Guild' });
+    const nonMember  = await insertUser({ username: 'nonmember', email: 'nonmember@test.com' });
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/members/${nonMember}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const guildId  = await insertGuildWithOwner(userId, { name: 'Auth Kick Guild' });
+    const memberId = await insertUser({ username: 'authmember', email: 'authmember@test.com' });
+    await insertGuildMember(memberId, guildId, 'Member');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/members/${memberId}`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test guild member promotion and demotion
+describe('PATCH /api/guilds/:id/members/:userId/role', () => {
+
+  test('200 - owner can promote member to officer', async () => {
+    const guildId  = await insertGuildWithOwner(userId, { name: 'Promote Guild' });
+    const memberId = await insertUser({ username: 'promoteme', email: 'promoteme@test.com' });
+    await insertGuildMember(memberId, guildId, 'Member');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/members/${memberId}/role`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ newRole: 'Officer' });
+
+    expect(res.status).toBe(200);
+
+    const [[row]] = await pool.query(
+      'SELECT ROLE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+      [memberId, guildId]
+    );
+    expect(row.ROLE).toBe('Officer');
+  });
+
+  test('200 - owner can demote officer to member', async () => {
+    const guildId    = await insertGuildWithOwner(userId, { name: 'Demote Guild' });
+    const officerId  = await insertUser({ username: 'demoteme', email: 'demoteme@test.com' });
+    await insertGuildMember(officerId, guildId, 'Officer');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/members/${officerId}/role`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ newRole: 'Member' });
+
+    expect(res.status).toBe(200);
+
+    const [[row]] = await pool.query(
+      'SELECT ROLE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+      [officerId, guildId]
+    );
+    expect(row.ROLE).toBe('Member');
+  });
+
+  test('200 - officer can promote member to officer', async () => {
+    const ownerId  = await insertUser({ username: 'roleown', email: 'roleown@test.com' });
+    const guildId  = await insertGuildWithOwner(ownerId, { name: 'Officer Promote Guild' });
+    await insertGuildMember(userId, guildId, 'Officer');
+    const memberId = await insertUser({ username: 'offpromoteme', email: 'offpromoteme@test.com' });
+    await insertGuildMember(memberId, guildId, 'Member');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/members/${memberId}/role`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ newRole: 'Officer' });
+
+    expect(res.status).toBe(200);
+  });
+
+  test('403 - officer cannot demote another officer', async () => {
+    const ownerId   = await insertUser({ username: 'roleown2', email: 'roleown2@test.com' });
+    const guildId   = await insertGuildWithOwner(ownerId, { name: 'Officer Demote Guild' });
+    await insertGuildMember(userId, guildId, 'Officer');
+    const officer2  = await insertUser({ username: 'officer2d', email: 'officer2d@test.com' });
+    await insertGuildMember(officer2, guildId, 'Officer');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/members/${officer2}/role`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ newRole: 'Member' });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('403 - member cannot promote or demote anyone', async () => {
+    const ownerId  = await insertUser({ username: 'memroleown', email: 'memroleown@test.com' });
+    const guildId  = await insertGuildWithOwner(ownerId, { name: 'Member Role Block Guild' });
+    await insertGuildMember(userId, guildId, 'Member');
+    const targetId = await insertUser({ username: 'memroletgt', email: 'memroletgt@test.com' });
+    await insertGuildMember(targetId, guildId, 'Member');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/members/${targetId}/role`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ newRole: 'Officer' });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('403 - cannot change Owner role', async () => {
+    const ownerId  = await insertUser({ username: 'roleown3', email: 'roleown3@test.com' });
+    const guildId  = await insertGuildWithOwner(ownerId, { name: 'Owner Role Guild' });
+    await insertGuildMember(userId, guildId, 'Officer');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/members/${ownerId}/role`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ newRole: 'Member' });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('400 - invalid role value', async () => {
+    const guildId  = await insertGuildWithOwner(userId, { name: 'Bad Role Guild' });
+    const memberId = await insertUser({ username: 'badrole', email: 'badrole@test.com' });
+    await insertGuildMember(memberId, guildId, 'Member');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/members/${memberId}/role`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ newRole: 'Supreme Commander' });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('401 - no auth token', async () => {
+    const guildId  = await insertGuildWithOwner(userId, { name: 'Auth Role Guild' });
+    const memberId = await insertUser({ username: 'authrole', email: 'authrole@test.com' });
+    await insertGuildMember(memberId, guildId, 'Member');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/members/${memberId}/role`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test guild equip/unequip
+describe('PUT /api/guilds/:id/equip and unequip', () => {
+
+  let guildId;
+  let guildItemId;
+
+  beforeEach(async () => {
+    guildId = await insertGuildWithOwner(userId, { name: 'Equip Guild' });
+
+    // Insert a guild flair item
+    const [itemResult] = await pool.query(
+      'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, 1)',
+      ['flair', 50, 'Guild Test Flair']
+    );
+    guildItemId = itemResult.insertId;
+
+    // Pre-unlock it for the guild
+    await pool.query(
+      'INSERT INTO GuildUnlock (GUILD_ID, ITEM_ID, IS_EQUIPPED) VALUES (?, ?, 0)',
+      [guildId, guildItemId]
+    );
+  });
+
+  afterEach(async () => {
+    await pool.query('DELETE FROM StoreItem WHERE ID = ?', [guildItemId]);
+  });
+
+  test('200 - officer or owner can equip an unlocked item', async () => {
+    const res = await request(app)
+      .put(`/api/guilds/${guildId}/equip`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ itemId: guildItemId });
+
+    expect(res.status).toBe(200);
+
+    const [[row]] = await pool.query(
+      'SELECT IS_EQUIPPED FROM GuildUnlock WHERE GUILD_ID = ? AND ITEM_ID = ?',
+      [guildId, guildItemId]
+    );
+    expect(row.IS_EQUIPPED).toBe(1);
+  });
+
+  test('400 - cannot equip already equipped item', async () => {
+    await pool.query(
+      'UPDATE GuildUnlock SET IS_EQUIPPED = 1 WHERE GUILD_ID = ? AND ITEM_ID = ?',
+      [guildId, guildItemId]
+    );
+
+    const res = await request(app)
+      .put(`/api/guilds/${guildId}/equip`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ itemId: guildItemId });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('403 - item not unlocked returns 403', async () => {
+    const [lockedResult] = await pool.query(
+      'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, 1)',
+      ['flair', 9999, 'Locked Guild Flair']
+    );
+    const lockedItemId = lockedResult.insertId;
+
+    const res = await request(app)
+      .put(`/api/guilds/${guildId}/equip`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ itemId: lockedItemId });
+
+    expect(res.status).toBe(403);
+
+    await pool.query('DELETE FROM StoreItem WHERE ID = ?', [lockedItemId]);
+  });
+
+  test('403 - member cannot equip', async () => {
+    // Clean up any existing membership for userId before this test
+    await pool.query('DELETE FROM GuildMember WHERE USER_ID = ?', [userId]);
+    const ownerId = await insertUser({ username: 'equipown', email: 'equipown@test.com' });
+    const memberGuildId = await insertGuildWithOwner(ownerId, { name: 'Member Equip Guild' });
+    await insertGuildMember(userId, memberGuildId, 'Member');
+
+    const [itemResult] = await pool.query(
+      'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, 1)',
+      ['flair', 0, 'Member Equip Flair']
+    );
+    const itemId = itemResult.insertId;
+    await pool.query(
+      'INSERT INTO GuildUnlock (GUILD_ID, ITEM_ID, IS_EQUIPPED) VALUES (?, ?, 0)',
+      [memberGuildId, itemId]
+    );
+
+    const res = await request(app)
+      .put(`/api/guilds/${memberGuildId}/equip`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ itemId });
+
+    expect(res.status).toBe(403);
+
+    await pool.query('DELETE FROM StoreItem WHERE ID = ?', [itemId]);
+  });
+
+  test('200 - equipping profile picture auto-swaps current one', async () => {
+    const [pic1Result] = await pool.query(
+      'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, 1)',
+      ['profile_picture', 10, 'Guild Pic 1']
+    );
+    const [pic2Result] = await pool.query(
+      'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, 1)',
+      ['profile_picture', 10, 'Guild Pic 2']
+    );
+    const pic1Id = pic1Result.insertId;
+    const pic2Id = pic2Result.insertId;
+
+    // Unlock and equip pic1
+    await pool.query('INSERT INTO GuildUnlock (GUILD_ID, ITEM_ID, IS_EQUIPPED) VALUES (?, ?, 1)', [guildId, pic1Id]);
+    // Unlock but don't equip pic2
+    await pool.query('INSERT INTO GuildUnlock (GUILD_ID, ITEM_ID, IS_EQUIPPED) VALUES (?, ?, 0)', [guildId, pic2Id]);
+
+    const res = await request(app)
+      .put(`/api/guilds/${guildId}/equip`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ itemId: pic2Id });
+
+    expect(res.status).toBe(200);
+
+    const [[old]] = await pool.query(
+      'SELECT IS_EQUIPPED FROM GuildUnlock WHERE GUILD_ID = ? AND ITEM_ID = ?',
+      [guildId, pic1Id]
+    );
+    expect(old.IS_EQUIPPED).toBe(0);
+
+    const [[current]] = await pool.query(
+      'SELECT IS_EQUIPPED FROM GuildUnlock WHERE GUILD_ID = ? AND ITEM_ID = ?',
+      [guildId, pic2Id]
+    );
+    expect(current.IS_EQUIPPED).toBe(1);
+
+    await pool.query('DELETE FROM StoreItem WHERE ID IN (?, ?)', [pic1Id, pic2Id]);
+  });
+
+  test('200 - owner can unequip an equipped item', async () => {
+    await pool.query(
+      'UPDATE GuildUnlock SET IS_EQUIPPED = 1 WHERE GUILD_ID = ? AND ITEM_ID = ?',
+      [guildId, guildItemId]
+    );
+
+    const res = await request(app)
+      .put(`/api/guilds/${guildId}/unequip`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ itemId: guildItemId });
+
+    expect(res.status).toBe(200);
+
+    const [[row]] = await pool.query(
+      'SELECT IS_EQUIPPED FROM GuildUnlock WHERE GUILD_ID = ? AND ITEM_ID = ?',
+      [guildId, guildItemId]
+    );
+    expect(row.IS_EQUIPPED).toBe(0);
+  });
+
+  test('400 - cannot unequip item that is not equipped', async () => {
+    const res = await request(app)
+      .put(`/api/guilds/${guildId}/unequip`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ itemId: guildItemId });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('401 - no auth token on equip', async () => {
+    const res = await request(app)
+      .put(`/api/guilds/${guildId}/equip`)
+      .send({ itemId: guildItemId });
+
+    expect(res.status).toBe(401);
+  });
+
+  test('200 - officer can equip an unlocked item', async () => {
+    // Clean up any existing membership for userId before this test
+    await pool.query('DELETE FROM GuildMember WHERE USER_ID = ?', [userId]);
+    const ownerId      = await insertUser({ username: 'offequipown', email: 'offequipown@test.com' });
+    const offGuildId   = await insertGuildWithOwner(ownerId, { name: 'Officer Equip Guild' });
+    await insertGuildMember(userId, offGuildId, 'Officer');
+
+    const [itemResult] = await pool.query(
+      'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, 1)',
+      ['flair', 0, 'Officer Equip Flair']
+    );
+    const itemId = itemResult.insertId;
+    await pool.query(
+      'INSERT INTO GuildUnlock (GUILD_ID, ITEM_ID, IS_EQUIPPED) VALUES (?, ?, 0)',
+      [offGuildId, itemId]
+    );
+
+    const res = await request(app)
+      .put(`/api/guilds/${offGuildId}/equip`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ itemId });
+
+    expect(res.status).toBe(200);
+
+    await pool.query('DELETE FROM StoreItem WHERE ID = ?', [itemId]);
+  });
+
+  test('200 - officer can unequip an equipped item', async () => {
+    // Clean up any existing membership for userId before this test
+    await pool.query('DELETE FROM GuildMember WHERE USER_ID = ?', [userId]);
+    const ownerId      = await insertUser({ username: 'offunequipown', email: 'offunequipown@test.com' });
+    const offGuildId   = await insertGuildWithOwner(ownerId, { name: 'Officer Unequip Guild' });
+    await insertGuildMember(userId, offGuildId, 'Officer');
+
+    const [itemResult] = await pool.query(
+      'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, 1)',
+      ['flair', 0, 'Officer Unequip Flair']
+    );
+    const itemId = itemResult.insertId;
+    await pool.query(
+      'INSERT INTO GuildUnlock (GUILD_ID, ITEM_ID, IS_EQUIPPED) VALUES (?, ?, 1)',
+      [offGuildId, itemId]
+    );
+
+    const res = await request(app)
+      .put(`/api/guilds/${offGuildId}/unequip`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ itemId });
+
+    expect(res.status).toBe(200);
+
+    await pool.query('DELETE FROM StoreItem WHERE ID = ?', [itemId]);
+  });
+});
+
+// Test leaving guild
+describe('DELETE /api/guilds/:id/leave', () => {
+
+  test('200 - member can leave a guild', async () => {
+    const ownerId = await insertUser({ username: 'leaveown', email: 'leaveown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Leave Member Guild' });
+    await insertGuildMember(userId, guildId, 'Member');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/leave`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    const [rows] = await pool.query(
+      'SELECT * FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+      [userId, guildId]
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test('200 - officer can leave a guild', async () => {
+    const ownerId = await insertUser({ username: 'leaveoffown', email: 'leaveoffown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Leave Officer Guild' });
+    await insertGuildMember(userId, guildId, 'Officer');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/leave`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    const [rows] = await pool.query(
+      'SELECT * FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+      [userId, guildId]
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test('403 - owner cannot leave their guild', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Owner Leave Guild' });
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/leave`)
+      .set('Authorization', `Bearer ${token}`);
+
+    // assertGuildRole excludes Owner, so this returns 403
+    expect(res.status).toBe(403);
+  });
+
+  test('403 - non-member cannot leave a guild', async () => {
+    const ownerId = await insertUser({ username: 'leavenonown', email: 'leavenonown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Non Member Leave Guild' });
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/leave`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('400 - invalid guild ID', async () => {
+    const res = await request(app)
+      .delete('/api/guilds/abc/leave')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  test('404 - guild not found', async () => {
+    const res = await request(app)
+      .delete('/api/guilds/999999/leave')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const ownerId = await insertUser({ username: 'leaveauthown', email: 'leaveauthown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Auth Leave Guild' });
+    await insertGuildMember(userId, guildId, 'Member');
+
+    const res = await request(app)
+      .delete(`/api/guilds/${guildId}/leave`);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/__test__/guildTests/guildEntry.test.js
+++ b/backend/__test__/guildTests/guildEntry.test.js
@@ -1,0 +1,669 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          guildEntry.test.js
+//  Description:   Integration tests for guild invite/request flow:
+//                 POST  /api/guilds/:id/invite
+//                 POST  /api/guilds/:id/request
+//                 PATCH /api/guilds/:id/entry/:userId
+//                 GET   /api/users/me/guild-invites
+//                 GET   /api/guilds/:id/requests
+//
+//  Dependencies:  supertest
+//                 mysql2 connection pool (server.js)
+//                 testHelpers
+//                 guildConfig
+//
+////////////////////////////////////////////////////////////////
+
+const request = require('supertest');
+const { app, pool } = require('../../server');
+const {
+        TEST_USER,
+        verifyTestDatabase,
+        getAuthToken,
+        insertUser,
+        insertGuildWithOwner,
+        insertGuildMember,
+      } = require('../testHelpers');
+const { MAX_GUILD_SIZE } = require('../../../shared/guildConfig');
+
+let token;
+let userId;
+
+beforeAll(async () => {
+  await verifyTestDatabase(pool);
+  await pool.query('DELETE FROM User');
+
+  token  = await getAuthToken();
+  const [rows] = await pool.query('SELECT ID FROM User WHERE EMAIL = ?', [TEST_USER.email]);
+  userId = rows[0].ID;
+});
+
+beforeEach(async () => {
+  await pool.query('DELETE FROM Guild');
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM User');
+  try { await pool.end(); }
+  catch (err) { console.error('Error closing pool in guildEntry.test.js:', err); }
+});
+
+// Test guild inviting
+describe('POST /api/guilds/:id/invite', () => {
+
+  test('200 - officer can invite a user', async () => {
+    const ownerId  = await insertUser({ username: 'inviteown', email: 'inviteown@test.com' });
+    const guildId  = await insertGuildWithOwner(ownerId, { name: 'Invite Guild' });
+    await insertGuildMember(userId, guildId, 'Officer');
+    const targetId = await insertUser({ username: 'invitetgt', email: 'invitetgt@test.com' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/invite`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ targetUserId: targetId });
+
+    expect(res.status).toBe(200);
+
+    const [entries] = await pool.query(
+      "SELECT * FROM GuildEntry WHERE USER_ID = ? AND GUILD_ID = ? AND TYPE = 'Invite'",
+      [targetId, guildId]
+    );
+    expect(entries).toHaveLength(1);
+  });
+
+  test('200 - owner can invite a user', async () => {
+    const guildId  = await insertGuildWithOwner(userId, { name: 'Owner Invite Guild' });
+    const targetId = await insertUser({ username: 'owninvtgt', email: 'owninvtgt@test.com' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/invite`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ targetUserId: targetId });
+
+    expect(res.status).toBe(200);
+  });
+
+  test('200 - inviting already-invited user is idempotent', async () => {
+    const guildId  = await insertGuildWithOwner(userId, { name: 'Idempotent Invite Guild' });
+    const targetId = await insertUser({ username: 'idemtgt', email: 'idemtgt@test.com' });
+
+    await request(app)
+      .post(`/api/guilds/${guildId}/invite`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ targetUserId: targetId });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/invite`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ targetUserId: targetId });
+
+    expect(res.status).toBe(200);
+
+    // Still only one entry row
+    const [entries] = await pool.query(
+      "SELECT * FROM GuildEntry WHERE USER_ID = ? AND GUILD_ID = ?",
+      [targetId, guildId]
+    );
+    expect(entries).toHaveLength(1);
+  });
+
+  test('400 - cannot invite existing member', async () => {
+    const guildId  = await insertGuildWithOwner(userId, { name: 'Member Invite Guild' });
+    const memberId = await insertUser({ username: 'alreadymember', email: 'alreadymember@test.com' });
+    await insertGuildMember(memberId, guildId, 'Member');
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/invite`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ targetUserId: memberId });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('403 - member cannot invite', async () => {
+    const ownerId  = await insertUser({ username: 'meminvown', email: 'meminvown@test.com' });
+    const guildId  = await insertGuildWithOwner(ownerId, { name: 'Member Invite Block Guild' });
+    await insertGuildMember(userId, guildId, 'Member');
+    const targetId = await insertUser({ username: 'meminvtgt', email: 'meminvtgt@test.com' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/invite`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ targetUserId: targetId });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('404 - target user not found', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'No Target Guild' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/invite`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ targetUserId: 999999 });
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const guildId  = await insertGuildWithOwner(userId, { name: 'Auth Invite Guild' });
+    const targetId = await insertUser({ username: 'authinvtgt', email: 'authinvtgt@test.com' });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/invite`)
+      .send({ targetUserId: targetId });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test requesting to join a guild
+describe('POST /api/guilds/:id/request', () => {
+
+  test('200 - user can request to join an open guild', async () => {
+    const ownerId = await insertUser({ username: 'reqown', email: 'reqown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Open Guild', isOpen: true });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/request`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    const [entries] = await pool.query(
+      "SELECT * FROM GuildEntry WHERE USER_ID = ? AND GUILD_ID = ? AND TYPE = 'Request'",
+      [userId, guildId]
+    );
+    expect(entries).toHaveLength(1);
+  });
+
+  test('403 - cannot request to join a closed guild', async () => {
+    const ownerId = await insertUser({ username: 'closeown', email: 'closeown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Closed Guild', isOpen: false });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/request`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('400 - cannot request if already a member', async () => {
+    const ownerId = await insertUser({ username: 'reqmemown', email: 'reqmemown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Already Member Guild', isOpen: true });
+    await insertGuildMember(userId, guildId, 'Member');
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/request`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  test('409 - guild owner cannot request to join another guild', async () => {
+    // Make test user an owner of their own guild
+    await insertGuildWithOwner(userId, { name: 'My Guild', isOpen: true });
+
+    const ownerId  = await insertUser({ username: 'reqown2', email: 'reqown2@test.com' });
+    const guildId2 = await insertGuildWithOwner(ownerId, { name: 'Other Open Guild', isOpen: true });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId2}/request`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(409);
+  });
+
+  test('404 - guild not found', async () => {
+    const res = await request(app)
+      .post('/api/guilds/999999/request')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const ownerId = await insertUser({ username: 'reqauthown', email: 'reqauthown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Auth Request Guild', isOpen: true });
+
+    const res = await request(app)
+      .post(`/api/guilds/${guildId}/request`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test accepting/rejecting entry
+describe('PATCH /api/guilds/:id/entry/:userId', () => {
+
+  test('200 - invitee can accept invite and becomes member', async () => {
+    const ownerId = await insertUser({ username: 'acceptown', email: 'acceptown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Accept Invite Guild' });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [userId, guildId]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'accept' });
+
+    expect(res.status).toBe(200);
+
+    const [members] = await pool.query(
+      'SELECT ROLE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+      [userId, guildId]
+    );
+    expect(members).toHaveLength(1);
+    expect(members[0].ROLE).toBe('Member');
+
+    // Entry row should be gone now
+    const [entries] = await pool.query(
+      'SELECT * FROM GuildEntry WHERE USER_ID = ? AND GUILD_ID = ?',
+      [userId, guildId]
+    );
+    expect(entries).toHaveLength(0);
+  });
+
+  test('200 - invitee can reject invite', async () => {
+    const ownerId = await insertUser({ username: 'rejectown', email: 'rejectown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Reject Invite Guild' });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [userId, guildId]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'reject' });
+
+    expect(res.status).toBe(200);
+
+    // Entry row should be gone now
+    const [entries] = await pool.query(
+      'SELECT * FROM GuildEntry WHERE USER_ID = ? AND GUILD_ID = ?',
+      [userId, guildId]
+    );
+    expect(entries).toHaveLength(0);
+  });
+
+  test('200 - officer can accept a join request', async () => {
+    const ownerId    = await insertUser({ username: 'reqaccown', email: 'reqaccown@test.com' });
+    const guildId    = await insertGuildWithOwner(ownerId, { name: 'Accept Request Guild', isOpen: true });
+    await insertGuildMember(userId, guildId, 'Officer');
+    const requesterId = await insertUser({ username: 'requester', email: 'requester@test.com' });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Request')",
+      [requesterId, guildId]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${requesterId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'accept' });
+
+    expect(res.status).toBe(200);
+
+    const [members] = await pool.query(
+      'SELECT ROLE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+      [requesterId, guildId]
+    );
+    expect(members).toHaveLength(1);
+    expect(members[0].ROLE).toBe('Member');
+  });
+
+  test('200 - officer can reject a join request', async () => {
+    const ownerId     = await insertUser({ username: 'reqrejown', email: 'reqrejown@test.com' });
+    const guildId     = await insertGuildWithOwner(ownerId, { name: 'Reject Request Guild', isOpen: true });
+    await insertGuildMember(userId, guildId, 'Officer');
+    const requesterId = await insertUser({ username: 'requester2', email: 'requester2@test.com' });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Request')",
+      [requesterId, guildId]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${requesterId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'reject' });
+
+    expect(res.status).toBe(200);
+
+    const [entries] = await pool.query(
+      'SELECT * FROM GuildEntry WHERE USER_ID = ? AND GUILD_ID = ?',
+      [requesterId, guildId]
+    );
+    expect(entries).toHaveLength(0);
+  });
+
+  test('200 - requires confirmation if user is in another guild, no action taken without confirmLeave', async () => {
+    const ownerId  = await insertUser({ username: 'confown', email: 'confown@test.com' });
+    const guildId  = await insertGuildWithOwner(ownerId, { name: 'Confirm Guild' });
+    const ownerId2 = await insertUser({ username: 'confown2', email: 'confown2@test.com' });
+    const guildId2 = await insertGuildWithOwner(ownerId2, { name: 'Confirm Guild 2' });
+
+    // Test user is already in guild2 as member
+    await insertGuildMember(userId, guildId2, 'Member');
+
+    // Invite test user to guild1
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [userId, guildId]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'accept' }); // no confirmLeave
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('requiresConfirmation', true);
+
+    // User should NOT have been moved yet
+    const [members] = await pool.query(
+      'SELECT GUILD_ID FROM GuildMember WHERE USER_ID = ?',
+      [userId]
+    );
+    expect(members[0].GUILD_ID).toBe(guildId2);
+  });
+
+  test('200 - confirmLeave moves user from old guild to new guild atomically', async () => {
+    const ownerId  = await insertUser({ username: 'leaveown', email: 'leaveown@test.com' });
+    const guildId  = await insertGuildWithOwner(ownerId, { name: 'Leave Guild' });
+    const ownerId2 = await insertUser({ username: 'leaveown2', email: 'leaveown2@test.com' });
+    const guildId2 = await insertGuildWithOwner(ownerId2, { name: 'Leave Guild 2' });
+    await insertGuildMember(userId, guildId2, 'Member');
+
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [userId, guildId]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'accept', confirmLeave: true });
+
+    expect(res.status).toBe(200);
+
+    const [members] = await pool.query(
+      'SELECT GUILD_ID FROM GuildMember WHERE USER_ID = ?',
+      [userId]
+    );
+    expect(members).toHaveLength(1);
+    expect(members[0].GUILD_ID).toBe(guildId);
+  });
+
+  test('200 - requires confirmation if user is an officer of another guild', async () => {
+    const ownerId  = await insertUser({ username: 'offconfown', email: 'offconfown@test.com' });
+    const guildId  = await insertGuildWithOwner(ownerId, { name: 'Officer Confirm Guild' });
+    const ownerId2 = await insertUser({ username: 'offconfown2', email: 'offconfown2@test.com' });
+    const guildId2 = await insertGuildWithOwner(ownerId2, { name: 'Officer Confirm Guild 2' });
+
+    // Test user is an officer in guild2
+    await insertGuildMember(userId, guildId2, 'Officer');
+
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [userId, guildId]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'accept' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('requiresConfirmation', true);
+
+    // User should still be in guild2
+    const [[membership]] = await pool.query(
+      'SELECT GUILD_ID FROM GuildMember WHERE USER_ID = ?',
+      [userId]
+    );
+    expect(membership.GUILD_ID).toBe(guildId2);
+  });
+
+  test('409 - owner of another guild cannot accept invite', async () => {
+    // Test user owns a guild
+    await insertGuildWithOwner(userId, { name: 'Owned Guild' });
+
+    const ownerId2 = await insertUser({ username: 'ownerblock', email: 'ownerblock@test.com' });
+    const guildId2 = await insertGuildWithOwner(ownerId2, { name: 'Inviting Guild' });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [userId, guildId2]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId2}/entry/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'accept' });
+
+    expect(res.status).toBe(409);
+  });
+
+  test('409 - guild is full', async () => {
+    const ownerId = await insertUser({ username: 'fullown', email: 'fullown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Full Guild' });
+
+    // Fill guild to max (owner already counts as 1)
+    for (let i = 1; i < MAX_GUILD_SIZE; i++)
+    {
+      const memberId = await insertUser({
+        username: `fullmember${i}`,
+        email:    `fullmember${i}@test.com`
+      });
+      await insertGuildMember(memberId, guildId, 'Member');
+    }
+
+    // Invite the test user
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [userId, guildId]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'accept' });
+
+    expect(res.status).toBe(409);
+  });
+
+  test('403 - non-invitee cannot accept an invite', async () => {
+    const ownerId    = await insertUser({ username: 'nonacc', email: 'nonacc@test.com' });
+    const guildId    = await insertGuildWithOwner(ownerId, { name: 'Non Acceptor Guild' });
+    const inviteeId  = await insertUser({ username: 'invitee', email: 'invitee@test.com' });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [inviteeId, guildId]
+    );
+
+    // Test user (not the invitee) tries to accept
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${inviteeId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'accept' });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('400 - invalid action', async () => {
+    const ownerId = await insertUser({ username: 'badactown', email: 'badactown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Bad Action Guild' });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [userId, guildId]
+    );
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'maybe' });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('404 - entry not found', async () => {
+    const ownerId = await insertUser({ username: 'noentryown', email: 'noentryown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'No Entry Guild' });
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${userId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ action: 'accept' });
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const ownerId = await insertUser({ username: 'authenown', email: 'authenown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Auth Entry Guild' });
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/entry/${userId}`)
+      .send({ action: 'accept' });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test fetching a user's invites
+// (Technically this is a user endpoint but it's kinda a hybrid guild-user endpoint)
+describe('GET /api/users/me/guild-invites', () => {
+
+  test('200 - returns pending invites for current user', async () => {
+    const ownerId = await insertUser({ username: 'myinvown', email: 'myinvown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'My Invite Guild' });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Invite')",
+      [userId, guildId]
+    );
+
+    const res = await request(app)
+      .get('/api/users/me/guild-invites')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('invites');
+    expect(res.body.invites.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.invites[0]).toHaveProperty('GUILD_ID', guildId);
+    expect(res.body.invites[0]).toHaveProperty('guildName', 'My Invite Guild');
+  });
+
+  test('200 - returns empty array when no invites', async () => {
+    const res = await request(app)
+      .get('/api/users/me/guild-invites')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.invites).toHaveLength(0);
+  });
+
+  test('200 - does not return REQUEST type entries', async () => {
+    const ownerId = await insertUser({ username: 'reqnotinv', email: 'reqnotinv@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Request Not Invite Guild', isOpen: true });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Request')",
+      [userId, guildId]
+    );
+
+    const res = await request(app)
+      .get('/api/users/me/guild-invites')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const guildIds = res.body.invites.map(i => i.GUILD_ID);
+    expect(guildIds).not.toContain(guildId);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .get('/api/users/me/guild-invites');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test fetching a guild's incoming requests to join
+describe('GET /api/guilds/:id/requests', () => {
+
+  test('200 - officer can view join requests', async () => {
+    const ownerId     = await insertUser({ username: 'viewreqown', email: 'viewreqown@test.com' });
+    const guildId     = await insertGuildWithOwner(ownerId, { name: 'View Requests Guild', isOpen: true });
+    await insertGuildMember(userId, guildId, 'Officer');
+    const requesterId = await insertUser({ username: 'viewreq', email: 'viewreq@test.com' });
+    await pool.query(
+      "INSERT INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, 'Request')",
+      [requesterId, guildId]
+    );
+
+    const res = await request(app)
+      .get(`/api/guilds/${guildId}/requests`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('requests');
+    expect(res.body.requests.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.requests[0]).toHaveProperty('USER_ID', requesterId);
+    expect(res.body.requests[0]).toHaveProperty('USERNAME');
+  });
+
+  test('200 - returns empty array when no requests', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Empty Requests Guild' });
+
+    const res = await request(app)
+      .get(`/api/guilds/${guildId}/requests`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requests).toHaveLength(0);
+  });
+
+  test('403 - member cannot view requests', async () => {
+    const ownerId = await insertUser({ username: 'memreqown', email: 'memreqown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Member Request Guild' });
+    await insertGuildMember(userId, guildId, 'Member');
+
+    const res = await request(app)
+      .get(`/api/guilds/${guildId}/requests`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('403 - non-member cannot view requests', async () => {
+    const ownerId = await insertUser({ username: 'nonmemreqown', email: 'nonmemreqown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Non Member Requests Guild' });
+
+    const res = await request(app)
+      .get(`/api/guilds/${guildId}/requests`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('404 - guild not found', async () => {
+    const res = await request(app)
+      .get('/api/guilds/999999/requests')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Auth Requests Guild' });
+
+    const res = await request(app)
+      .get(`/api/guilds/${guildId}/requests`);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/__test__/guildTests/guildEntry.test.js
+++ b/backend/__test__/guildTests/guildEntry.test.js
@@ -8,6 +8,7 @@
 //                 POST  /api/guilds/:id/invite
 //                 POST  /api/guilds/:id/request
 //                 PATCH /api/guilds/:id/entry/:userId
+//                 PATCH /api/guilds/:id/open
 //                 GET   /api/users/me/guild-invites
 //                 GET   /api/guilds/:id/requests
 //
@@ -666,4 +667,146 @@ describe('GET /api/guilds/:id/requests', () => {
 
     expect(res.status).toBe(401);
   });
+});
+
+// Test guild opening/closing
+describe('PATCH /api/guilds/:id/open', () => {
+
+  test('200 - owner can open guild', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Open Toggle Guild', isOpen: false });
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('isOpen', true);
+
+    const [[guild]] = await pool.query('SELECT IS_OPEN FROM Guild WHERE ID = ?', [guildId]);
+    expect(guild.IS_OPEN).toBe(1);
+  });
+
+  test('200 - owner can close guild', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Close Toggle Guild', isOpen: true });
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('isOpen', false);
+
+    const [[guild]] = await pool.query('SELECT IS_OPEN FROM Guild WHERE ID = ?', [guildId]);
+    expect(guild.IS_OPEN).toBe(0);
+  });
+
+  test('200 - officer can open/close guild', async () => {
+    const ownerId = await insertUser({ username: 'openown', email: 'openown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Officer Open Guild', isOpen: false });
+    await insertGuildMember(userId, guildId, 'Officer');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: true });
+
+    expect(res.status).toBe(200);
+  });
+
+  test('200 - setting same value twice is idempotent', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Idempotent Open Guild', isOpen: true });
+
+    await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: true });
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: true });
+
+    expect(res.status).toBe(200);
+
+    const [[guild]] = await pool.query('SELECT IS_OPEN FROM Guild WHERE ID = ?', [guildId]);
+    expect(guild.IS_OPEN).toBe(1);
+  });
+
+  test('400 - rejects non-boolean isOpen', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Bad Open Guild' });
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: 'yes' });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('400 - rejects missing isOpen field', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Missing Open Guild' });
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  test('403 - member cannot update open status', async () => {
+    const ownerId = await insertUser({ username: 'memopnown', email: 'memopnown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Member Open Guild' });
+    await insertGuildMember(userId, guildId, 'Member');
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: true });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('403 - non-member cannot update open status', async () => {
+    const ownerId = await insertUser({ username: 'nonmemopnown', email: 'nonmemopnown@test.com' });
+    const guildId = await insertGuildWithOwner(ownerId, { name: 'Non Member Open Guild' });
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: true });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('400 - invalid guild ID', async () => {
+    const res = await request(app)
+      .patch('/api/guilds/abc/open')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: true });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('404 - guild not found', async () => {
+    const res = await request(app)
+      .patch('/api/guilds/2147483647/open')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isOpen: true });
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const guildId = await insertGuildWithOwner(userId, { name: 'Auth Open Guild' });
+
+    const res = await request(app)
+      .patch(`/api/guilds/${guildId}/open`)
+      .send({ isOpen: true });
+
+    expect(res.status).toBe(401);
+  });
+
 });

--- a/backend/__test__/guildTests/guildLeaderboard.test.js
+++ b/backend/__test__/guildTests/guildLeaderboard.test.js
@@ -1,0 +1,253 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          guildLeaderboard.test.js
+//  Description:   Integration tests for guild leaderboard endpoints:
+//                 GET /api/leaderboard/guilds/weekly
+//                 GET /api/leaderboard/guilds/lifetime
+//
+//  Dependencies:  supertest
+//                 mysql2 connection pool (server.js)
+//                 testHelpers
+//
+////////////////////////////////////////////////////////////////
+
+const request = require('supertest');
+const { app, pool } = require('../../server');
+const {
+        TEST_USER,
+        verifyTestDatabase,
+        getAuthToken,
+        insertUser,
+        insertGuildWithOwner,
+        insertGuildMember,
+      } = require('../testHelpers');
+
+let token;
+let userId;
+
+// Guild IDs seeded for leaderboard tests
+let guildIds = [];
+
+beforeAll(async () => {
+  await verifyTestDatabase(pool);
+  await pool.query('DELETE FROM User');
+  await pool.query('DELETE FROM Guild');
+
+  token = await getAuthToken();
+  const [rows] = await pool.query('SELECT ID FROM User WHERE EMAIL = ?', [TEST_USER.email]);
+  userId = rows[0].ID;
+
+  // Insert three guild owners
+  const ownerAId = await insertUser({ username: 'lb_owner_a', email: 'lb_owner_a@test.com' });
+  const ownerBId = await insertUser({ username: 'lb_owner_b', email: 'lb_owner_b@test.com' });
+  const ownerCId = await insertUser({ username: 'lb_owner_c', email: 'lb_owner_c@test.com' });
+
+  // Insert guilds with known exp values
+  // Guild A: highest exp
+  const guildAId = await insertGuildWithOwner(ownerAId, { name: 'Guild Alpha', weeklyExp: 900, lifetimeExp: 9000 });
+  // Guild B: middle exp, test user's guild
+  const guildBId = await insertGuildWithOwner(ownerBId, { name: 'Guild Beta', weeklyExp: 600, lifetimeExp: 6000 });
+  // Guild C: lowest exp
+  const guildCId = await insertGuildWithOwner(ownerCId, { name: 'Guild Gamma', weeklyExp: 300, lifetimeExp: 3000 });
+
+  guildIds = [guildAId, guildBId, guildCId];
+
+  // Make test user a member of Guild B so they have a guild rank to assert
+  await insertGuildMember(userId, guildBId, 'Member');
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM Guild');
+  await pool.query('DELETE FROM User');
+  try { await pool.end(); }
+  catch (err) { console.error('Error closing pool in guildLeaderboard.test.js:', err); }
+});
+
+// Test weekly guild leaderboard
+describe('GET /api/leaderboard/guilds/weekly', () => {
+
+  test('200 - returns leaderboard with correct shape', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('leaderboard');
+    expect(res.body).toHaveProperty('page');
+    expect(res.body).toHaveProperty('totalPages');
+    expect(res.body).toHaveProperty('guildRank');
+    expect(res.body).toHaveProperty('guildExp');
+    expect(res.body).toHaveProperty('guildId');
+  });
+
+  test('200 - leaderboard entries have correct fields', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leaderboard.length).toBeGreaterThan(0);
+
+    const entry = res.body.leaderboard[0];
+    expect(entry).toHaveProperty('rank');
+    expect(entry).toHaveProperty('id');
+    expect(entry).toHaveProperty('name');
+    expect(entry).toHaveProperty('exp');
+    expect(entry).toHaveProperty('guildPicture');
+  });
+
+  test('200 - guilds ranked highest exp first', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const names = res.body.leaderboard.map(g => g.name);
+    expect(names[0]).toBe('Guild Alpha');
+    expect(names[1]).toBe('Guild Beta');
+    expect(names[2]).toBe('Guild Gamma');
+  });
+
+  test('200 - rank 1 guild has highest weekly exp', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leaderboard[0].rank).toBe(1);
+    expect(res.body.leaderboard[0].exp).toBe(900);
+  });
+
+  test('200 - returns requesting user guild rank and exp', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    // Test user is in Guild B which has rank 2
+    expect(res.body.guildRank).toBe(2);
+    expect(res.body.guildExp).toBe(600);
+    expect(res.body.guildId).toBe(guildIds[1]);
+  });
+
+  test('200 - guildRank, guildExp, guildId are null when user not in a guild', async () => {
+    // Insert a user with no guild membership
+    const noGuildUserId = await insertUser({ username: 'no_guild_user', email: 'no_guild@test.com' });
+    const noGuildToken  = await (async () => {
+      const bcrypt = require('bcryptjs');
+      const hashed = await bcrypt.hash('Testpass123!', 10);
+      await pool.query(
+        'UPDATE User SET PASSWORD = ? WHERE ID = ?',
+        [hashed, noGuildUserId]
+      );
+      // Login directly
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ username: 'no_guild_user', password: 'Testpass123!' });
+      return res.body.token;
+    })();
+
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly')
+      .set('Authorization', `Bearer ${noGuildToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.guildRank).toBeNull();
+    expect(res.body.guildExp).toBeNull();
+    expect(res.body.guildId).toBeNull();
+
+    await pool.query('DELETE FROM User WHERE ID = ?', [noGuildUserId]);
+  });
+
+  test('200 - pagination metadata is correct', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly?page=1')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(1);
+    expect(res.body.totalPages).toBeGreaterThanOrEqual(1);
+  });
+
+  test('200 - out of range page clamps to last page', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly?page=99999')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(res.body.totalPages);
+  });
+
+  test('200 - invalid page clamps to 1', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly?page=abc')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(1);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/weekly');
+
+    expect(res.status).toBe(401);
+  });
+
+});
+
+// Test lifetime guild leaderboard
+describe('GET /api/leaderboard/guilds/lifetime', () => {
+
+  test('200 - returns leaderboard with correct shape', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/lifetime')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('leaderboard');
+    expect(res.body).toHaveProperty('guildRank');
+    expect(res.body).toHaveProperty('guildExp');
+  });
+
+  test('200 - guilds ranked by lifetime exp', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/lifetime')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const names = res.body.leaderboard.map(g => g.name);
+    expect(names[0]).toBe('Guild Alpha');
+    expect(names[2]).toBe('Guild Gamma');
+  });
+
+  test('200 - rank 1 guild has highest lifetime exp', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/lifetime')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leaderboard[0].rank).toBe(1);
+    expect(res.body.leaderboard[0].exp).toBe(9000);
+  });
+
+  test('200 - user guild rank reflects lifetime exp ranking', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/lifetime')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.guildRank).toBe(2);
+    expect(res.body.guildExp).toBe(6000);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/guilds/lifetime');
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/__test__/guildTests/guildName.test.js
+++ b/backend/__test__/guildTests/guildName.test.js
@@ -1,0 +1,137 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          guildName.test.js
+//  Description:   Integration tests for guild name generation:
+//                 GET /api/guilds/name/generate
+//
+//  Dependencies:  supertest
+//                 mysql2 connection pool (server.js)
+//                 testHelpers
+//                 guildNames
+//
+////////////////////////////////////////////////////////////////
+
+const request = require('supertest');
+const { app, pool } = require('../../server');
+const { getAuthToken, verifyTestDatabase, insertGuild } = require('../testHelpers');
+const guildNames = require('../../config/guildNames');
+
+// Mock tiny word bank so we don't have to insert
+// hundreds of test guilds to exhaust all available names
+jest.mock('../../config/guildNames', () => ({
+  adjectives: ['Ancient', 'Blazing'],
+  pluralNouns: ['Wolves', 'Dragons'],
+}));
+
+let token;
+let guildOwnerIds = [];
+
+// Guild owners are unique so we'll need 4 users
+// for the 4 guilds we use in this test
+const GUILD_OWNERS = [
+  { username: 'guild_owner1' },
+  { username: 'guild_owner2' },
+  { username: 'guild_owner3' },
+  { username: 'guild_owner4' },
+];
+
+beforeAll(async () => {
+  await verifyTestDatabase(pool);
+  token = await getAuthToken();
+
+  // Insert guild owners for test
+  for (const u of GUILD_OWNERS)
+  {
+    const [result] = await pool.query(
+      `INSERT INTO User (USERNAME, EMAIL, PASSWORD) VALUES (?, ?, 'placeholder')`,
+      [u.username, `${u.username}@test.com`]
+    );
+    guildOwnerIds.push(result.insertId);
+  }
+});
+
+afterEach(async () => {
+  await pool.query('DELETE FROM Guild');
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM User');
+  try
+  {
+    await pool.end();
+  }
+  catch (err)
+  {
+    console.error('Error closing pool in guildName.test.js:', err);
+  }
+});
+
+// Test generating guild names
+describe('GET /api/guilds/name/generate', () => {
+
+  test('200 - returns a valid guild name', async () => {
+    const res = await request(app)
+      .get('/api/guilds/name/generate')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('name');
+    expect(typeof res.body.name).toBe('string');
+  });
+
+  test('200 - returned name is a valid adjective and plural noun from word bank', async () => {
+    const res = await request(app)
+      .get('/api/guilds/name/generate')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    // In case we ever make nouns multiple words
+    const [adjective, ...nounParts] = res.body.name.split(' ');
+    const noun = nounParts.join(' ');
+
+    expect(guildNames.adjectives).toContain(adjective);
+    expect(guildNames.pluralNouns).toContain(noun);
+  });
+
+  test('200 - does not return a name already taken by an existing guild', async () => {
+    // Mock bank is 2x2, leave only one combination available
+    const namesToInsert = ['Ancient Wolves', 'Ancient Dragons', 'Blazing Wolves'];
+    for (let i = 0; i < namesToInsert.length; i++)
+    {
+      await insertGuild({ name: namesToInsert[i], ownerId: guildOwnerIds[i] });
+    }
+    // 'Blazing Dragons' is the only one left
+
+    const res = await request(app)
+      .get('/api/guilds/name/generate')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Blazing Dragons');
+  });
+
+  test('503 - all guild name combinations are taken', async () => {
+    // Insert a guild for all 4 combinations
+    const namesToInsert = ['Ancient Wolves', 'Ancient Dragons', 'Blazing Wolves', 'Blazing Dragons'];
+    for (let i = 0; i < namesToInsert.length; i++)
+    {
+      await insertGuild({ name: namesToInsert[i], ownerId: guildOwnerIds[i] });
+    }
+
+    const res = await request(app)
+      .get('/api/guilds/name/generate')
+      .set('Authorization', `Bearer ${token}`);
+
+    // Looks like we gotta add more names!
+    expect(res.status).toBe(503);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app).get('/api/guilds/name/generate');
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/__test__/leaderboard.test.js
+++ b/backend/__test__/leaderboard.test.js
@@ -17,7 +17,13 @@
 
 const request = require('supertest');
 const { app, pool } = require('../server');
-const { TEST_USER, getAuthToken, verifyTestDatabase, insertPurchase } = require('./testHelpers');
+const { 
+        TEST_USER,
+        getAuthToken,
+        verifyTestDatabase,
+        insertPurchase,
+        insertUser,
+      } = require('./testHelpers');
 const { ITEM_TYPES } = require('../../shared/itemConfig');
 
 let token;
@@ -318,6 +324,187 @@ describe('GET /api/leaderboard/lifetime', () => {
   test('401 - missing token', async () => {
     const res = await request(app)
       .get('/api/leaderboard/lifetime');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test followed weekly leaderboard endpoint
+describe('GET /api/leaderboard/followed/weekly', () => {
+
+  // Insert a follow relationship before each test, clean up after
+  let followeeId;
+  beforeEach(async () => {
+    followeeId = await insertUser({
+      username:   'followed_user',
+      email:      'followed@test.com',
+      weeklyExp:  600,
+      lifetimeExp: 1000,
+    });
+    await pool.query(
+      'INSERT INTO Follower (FOLLOWER_ID, FOLLOWING_ID) VALUES (?, ?)',
+      [userId, followeeId]
+    );
+  });
+  afterEach(async () => {
+    await pool.query('DELETE FROM User WHERE ID = ?', [followeeId]);
+  });
+
+  test('200 - returns correct shape', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/followed/weekly')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('userRank');
+    expect(res.body).toHaveProperty('userExp');
+    expect(res.body).toHaveProperty('page');
+    expect(res.body).toHaveProperty('totalPages');
+    expect(res.body).toHaveProperty('leaderboard');
+    expect(Array.isArray(res.body.leaderboard)).toBe(true);
+  });
+
+  test('200 - only shows followed users, not all users', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/followed/weekly')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    // lb_user1/2/3 from the global setup are not followed, shouldn't appear
+    const usernames = res.body.leaderboard.map(e => e.username);
+    expect(usernames).not.toContain('lb_user1');
+    expect(usernames).not.toContain('lb_user2');
+    expect(usernames).not.toContain('lb_user3');
+    expect(usernames).toContain('followed_user');
+  });
+
+  test('200 - returns empty leaderboard when following nobody', async () => {
+    // Remove the follow relationship set up in beforeEach
+    await pool.query(
+      'DELETE FROM Follower WHERE FOLLOWER_ID = ? AND FOLLOWING_ID = ?',
+      [userId, followeeId]
+    );
+
+    const res = await request(app)
+      .get('/api/leaderboard/followed/weekly')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leaderboard).toHaveLength(0);
+    expect(res.body.totalPages).toBe(0);
+    expect(res.body.userRank).toBeNull();
+    expect(res.body.userExp).toBeNull();
+  });
+
+  test('200 - userRank and userExp reflect test user weekly exp within followed pool', async () => {
+    await pool.query(
+      'UPDATE User SET WEEKLY_EXP = 100 WHERE ID = ?',
+      [userId]
+    );
+
+    const res = await request(app)
+      .get('/api/leaderboard/followed/weekly')
+      .set('Authorization', `Bearer ${token}`);
+
+    // followee has 600, test user has 100, userRank is from global pool, not followed pool
+    expect(res.status).toBe(200);
+    expect(Number(res.body.userExp)).toBe(100);
+  });
+
+  test('200 - followed leaderboard rankings are independent of global leaderboard', async () => {
+    const [global, followed] = await Promise.all([
+      request(app).get('/api/leaderboard/weekly').set('Authorization', `Bearer ${token}`),
+      request(app).get('/api/leaderboard/followed/weekly').set('Authorization', `Bearer ${token}`)
+    ]);
+
+    expect(global.body.leaderboard.length).toBeGreaterThan(followed.body.leaderboard.length);
+  });
+
+  test('200 - out of range page clamps to last page', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/followed/weekly?page=999999')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(res.body.totalPages);
+  });
+
+  test('401 - missing token', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/followed/weekly');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test followed lifetime leaderboard endpoint
+describe('GET /api/leaderboard/followed/lifetime', () => {
+
+  let followeeId;
+  beforeEach(async () => {
+    followeeId = await insertUser({
+      username:    'followed_user',
+      email:       'followed@test.com',
+      weeklyExp:   600,
+      lifetimeExp: 1000,
+    });
+    await pool.query(
+      'INSERT INTO Follower (FOLLOWER_ID, FOLLOWING_ID) VALUES (?, ?)',
+      [userId, followeeId]
+    );
+  });
+  afterEach(async () => {
+    await pool.query('DELETE FROM User WHERE ID = ?', [followeeId]);
+  });
+
+  test('200 - returns correct shape', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/followed/lifetime')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('userRank');
+    expect(res.body).toHaveProperty('userExp');
+    expect(res.body).toHaveProperty('page');
+    expect(res.body).toHaveProperty('totalPages');
+    expect(res.body).toHaveProperty('leaderboard');
+    expect(Array.isArray(res.body.leaderboard)).toBe(true);
+  });
+
+  test('200 - returns empty leaderboard when following nobody', async () => {
+    await pool.query(
+      'DELETE FROM Follower WHERE FOLLOWER_ID = ? AND FOLLOWING_ID = ?',
+      [userId, followeeId]
+    );
+
+    const res = await request(app)
+      .get('/api/leaderboard/followed/lifetime')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leaderboard).toHaveLength(0);
+    expect(res.body.totalPages).toBe(0);
+  });
+
+  test('200 - weekly and lifetime followed rankings are independent', async () => {
+    await pool.query(
+      'UPDATE User SET WEEKLY_EXP = 0, LIFETIME_EXP = 1000 WHERE ID = ?',
+      [userId]
+    );
+
+    const [weekly, lifetime] = await Promise.all([
+      request(app).get('/api/leaderboard/followed/weekly').set('Authorization', `Bearer ${token}`),
+      request(app).get('/api/leaderboard/followed/lifetime').set('Authorization', `Bearer ${token}`)
+    ]);
+
+    expect(Number(weekly.body.userExp)).toBe(0);
+    expect(Number(lifetime.body.userExp)).toBe(1000);
+  });
+
+  test('401 - missing token', async () => {
+    const res = await request(app)
+      .get('/api/leaderboard/followed/lifetime');
 
     expect(res.status).toBe(401);
   });

--- a/backend/__test__/stats.test.js
+++ b/backend/__test__/stats.test.js
@@ -112,10 +112,6 @@ beforeAll(async () => {
   }));
 });
 
-beforeEach(() => {
-  jest.clearAllMocks();
-});
-
 afterAll(async () => {
   await pool.query('DELETE FROM User');
   try

--- a/backend/__test__/stats.test.js
+++ b/backend/__test__/stats.test.js
@@ -1,0 +1,417 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          stats.test.js
+//  Description:   Integration tests for aggregate stats routes:
+//                 GET /api/stats/aggregate
+//                 GET /api/stats/aggregate/:questionId
+//
+//  Dependencies:  supertest
+//                 mysql2 connection pool (server.js)
+//                 testHelpers
+//
+////////////////////////////////////////////////////////////////
+
+const request = require('supertest');
+const { app, pool } = require('../server');
+const {
+        verifyTestDatabase,
+        getAuthToken,
+        getProfAuthToken,
+        insertUser,
+        insertQuestion,
+        insertResponse,
+      } = require('./testHelpers');
+
+let studentToken;
+let profToken;
+let adminToken;
+let questionId;
+
+// Opted-in user IDs for stats tests
+let optedInUserIds  = [];
+// Opted-out user ID for filtering tests
+let optedOutUserId;
+// Response IDs for cleanup
+let responseIds = [];
+
+beforeAll(async () => {
+  await verifyTestDatabase(pool);
+  await pool.query('DELETE FROM User');
+
+  studentToken = await getAuthToken();
+  profToken    = await getProfAuthToken();
+  adminToken   = process.env.ADMIN_KEY;
+
+  // Insert a published question to attach responses to
+  questionId = await insertQuestion('Multiple Choice', [
+    { text: 'Correct', isCorrect: true,  rank: 1, placement: '' },
+    { text: 'Wrong',   isCorrect: false, rank: 2, placement: '' },
+  ], { points: 2.00, isPublished: true });
+
+  // Insert opted-in users with known response data
+  // User A: perfect score, fast
+  const userAId = await insertUser({
+    username: 'optedin_a',
+    email:    'optedin_a@test.com',
+    isSharingStats: true,
+  });
+  optedInUserIds.push(userAId);
+  responseIds.push(await insertResponse(userAId, questionId, {
+    pointsEarned:   2,
+    pointsPossible: 2,
+    isCorrect:      true,
+    elapsedTime:    30,
+    topic:          'Arrays',
+  }));
+
+  // User B: half score, medium time
+  const userBId = await insertUser({
+    username: 'optedin_b',
+    email:    'optedin_b@test.com',
+    isSharingStats: true,
+  });
+  optedInUserIds.push(userBId);
+  responseIds.push(await insertResponse(userBId, questionId, {
+    pointsEarned:   1,
+    pointsPossible: 2,
+    isCorrect:      false,
+    elapsedTime:    60,
+    topic:          'Arrays',
+  }));
+
+  // User C: zero score, slow, opted-in, tests median skew time resistance
+  const userCId = await insertUser({
+    username: 'optedin_c',
+    email:    'optedin_c@test.com',
+    isSharingStats: true,
+  });
+  optedInUserIds.push(userCId);
+  responseIds.push(await insertResponse(userCId, questionId, {
+    pointsEarned:   0,
+    pointsPossible: 2,
+    isCorrect:      false,
+    elapsedTime:    290,
+    topic:          'Arrays',
+  }));
+
+  // Opted-out user: should never appear in aggregate results
+  optedOutUserId = await insertUser({
+    username: 'optedout',
+    email:    'optedout@test.com',
+    isSharingStats: false,
+  });
+  responseIds.push(await insertResponse(optedOutUserId, questionId, {
+    pointsEarned:   2,
+    pointsPossible: 2,
+    isCorrect:      true,
+    elapsedTime:    10,
+    topic:          'Arrays',
+  }));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM User');
+  try
+  {
+    await pool.end();
+  }
+  catch (err)
+  {
+    console.error('Error closing pool in stats.test.js:', err);
+  }
+});
+
+// Test aggregate stats across all questions
+describe('GET /api/stats/aggregate', () => {
+
+  test('200 - professor can access aggregate stats', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('200 - admin can access aggregate stats', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('200 - response shape is correct', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('medianAccuracy');
+    expect(res.body).toHaveProperty('medianElapsedTime');
+    expect(res.body).toHaveProperty('responseCount');
+    expect(res.body).toHaveProperty('subcategoryBreakdown');
+  });
+
+  test('200 - only includes opted-in users', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    // 3 opted-in users, 1 opted-out, should only count 3
+    expect(res.body.responseCount).toBe(3);
+  });
+
+  test('200 - median accuracy computed correctly', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    // Accuracies: 1.0, 0.5, 0.0
+    // Sorted: [0.0, 0.5, 1.0]
+    // So median would be 0.5
+    expect(res.status).toBe(200);
+    expect(res.body.medianAccuracy).toBeCloseTo(0.5, 5);
+  });
+
+  test('200 - median elapsed time computed correctly', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    // Elapsed times: 30, 60, 290
+    // Sorted: [30, 60, 290]
+    // So median would be 60
+    expect(res.status).toBe(200);
+    expect(res.body.medianElapsedTime).toBe(60);
+  });
+
+  test('200 - subcategory breakdown present and correct', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.subcategoryBreakdown).toHaveProperty('Arrays');
+    expect(res.body.subcategoryBreakdown['Arrays']).toHaveProperty('medianAccuracy');
+    expect(res.body.subcategoryBreakdown['Arrays']).toHaveProperty('medianElapsedTime');
+    expect(res.body.subcategoryBreakdown['Arrays']).toHaveProperty('responseCount', 3);
+  });
+
+  test('200 - returns nulls and empty breakdown when no opted-in responses exist', async () => {
+    // Temporarily opt everyone out
+    await pool.query(
+      'UPDATE User SET IS_SHARING_STATS = 0 WHERE ID IN (?)',
+      [optedInUserIds]
+    );
+
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.medianAccuracy).toBeNull();
+    expect(res.body.medianElapsedTime).toBeNull();
+    expect(res.body.responseCount).toBe(0);
+    expect(res.body.subcategoryBreakdown).toEqual({});
+
+    // Opt them back in
+    await pool.query(
+      'UPDATE User SET IS_SHARING_STATS = 1 WHERE ID IN (?)',
+      [optedInUserIds]
+    );
+  });
+
+  test('200 - null elapsed times excluded from median elapsed time', async () => {
+    // Insert a response with null elapsed time from an opted-in user
+    const nullTimeUserId = await insertUser({
+      username: 'nulltime_user',
+      email:    'nulltime@test.com',
+      isSharingStats: true,
+    });
+    optedInUserIds.push(nullTimeUserId);
+
+    const nullTimeResponseId = await insertResponse(nullTimeUserId, questionId, {
+      pointsEarned:   1,
+      pointsPossible: 2,
+      elapsedTime:    null, // explicitly null
+      topic:          'Arrays',
+    });
+    responseIds.push(nullTimeResponseId);
+
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    // medianElapsedTime should still be computable from the non-null values
+    expect(res.status).toBe(200);
+    expect(res.body.medianElapsedTime).not.toBeNull();
+
+    // Cleanup
+    await pool.query('DELETE FROM User WHERE ID = ?', [nullTimeUserId]);
+  });
+
+  test('403 - student cannot access aggregate stats', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate')
+      .set('Authorization', `Bearer ${studentToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate');
+
+    expect(res.status).toBe(401);
+  });
+
+});
+
+// Test aggregate stats for a single question
+describe('GET /api/stats/aggregate/:questionId', () => {
+
+  test('200 - professor can access per-question stats', async () => {
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${questionId}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('200 - admin can access per-question stats', async () => {
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${questionId}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('200 - response shape is correct', async () => {
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${questionId}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('questionId', questionId);
+    expect(res.body).toHaveProperty('medianAccuracy');
+    expect(res.body).toHaveProperty('medianElapsedTime');
+    expect(res.body).toHaveProperty('responseCount');
+  });
+
+  test('200 - only includes opted-in users', async () => {
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${questionId}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.responseCount).toBe(3);
+  });
+
+  test('200 - median accuracy computed correctly for question', async () => {
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${questionId}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    // Same three opted-in responses: accuracies 1.0, 0.5, 0.0, median 0.5
+    expect(res.body.medianAccuracy).toBeCloseTo(0.5, 5);
+  });
+
+  test('200 - median elapsed time computed correctly for question', async () => {
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${questionId}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    // Elapsed: 30, 60, 290, median 60
+    expect(res.body.medianElapsedTime).toBe(60);
+  });
+
+  test('200 - returns nulls when no opted-in responses for question', async () => {
+    // Insert a question that nobody answered
+    const unansweredQuestionId = await insertQuestion('Multiple Choice', [
+      { text: 'A', isCorrect: true, rank: 1, placement: '' },
+    ], { points: 1.00, isPublished: true });
+
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${unansweredQuestionId}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.medianAccuracy).toBeNull();
+    expect(res.body.medianElapsedTime).toBeNull();
+    expect(res.body.responseCount).toBe(0);
+
+    // Cleanup
+    await pool.query('DELETE FROM Question WHERE ID = ?', [unansweredQuestionId]);
+  });
+
+  test('200 - scoped to question, does not bleed across questions', async () => {
+    // Insert a second question and response for an opted-in user
+    const secondQuestionId = await insertQuestion('Multiple Choice', [
+      { text: 'A', isCorrect: true, rank: 1, placement: '' },
+    ], { points: 2.00, isPublished: true });
+
+    const secondResponseId = await insertResponse(optedInUserIds[0], secondQuestionId, {
+      pointsEarned:   2,
+      pointsPossible: 2,
+      isCorrect:      true,
+      elapsedTime:    10,
+      topic:          'Strings',
+    });
+
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${questionId}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    // responseCount should still be 3, not 4
+    expect(res.body.responseCount).toBe(3);
+
+    await pool.query('DELETE FROM Question WHERE ID = ?', [secondQuestionId]);
+  });
+
+  test('400 - invalid question ID', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate/abc')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  test('400 - non-positive question ID', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate/-1')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  test('404 - question does not exist', async () => {
+    const res = await request(app)
+      .get('/api/stats/aggregate/999999')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('403 - student cannot access per-question stats', async () => {
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${questionId}`)
+      .set('Authorization', `Bearer ${studentToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .get(`/api/stats/aggregate/${questionId}`);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/__test__/test.test.js
+++ b/backend/__test__/test.test.js
@@ -9,7 +9,6 @@
 //  Dependencies:  supertest
 //                 mysql2 connection pool (server.js)
 //                 testHelpers
-//                 discordWebhook (mocked)
 //                 currencyConfig
 //
 ////////////////////////////////////////////////////////////////
@@ -23,13 +22,6 @@ const { TEST_USER,
         submitAndFetch,
       } = require("./testHelpers");
 const { DAILY_EXP_CAP, EXP_PER_POINT, COINS_PER_POINT } = require('../../shared/currencyConfig');
-
-// Mock Discord webhook
-jest.mock('../services/discordWebhook', () => ({
-  sendNotification: jest.fn().mockResolvedValue(true),
-  notifyUserEvent: jest.fn().mockResolvedValue(true),
-  notifyError: jest.fn().mockResolvedValue(true),
-}));
 
 let token;
 

--- a/backend/__test__/testHelpers.js
+++ b/backend/__test__/testHelpers.js
@@ -30,6 +30,36 @@ const TEST_USER = {
 };
 
 /**
+ * Inserts a generic user with the specified parameters
+ * NOTE: Avoid inserting multiple users with duplicate info
+ *       that should be unique (email, username)
+ * @param {string}  firstName       - First name of the user to insert. Default 'Generic'
+ * @param {string}  lastName        - First name of the user to insert. Default 'User'
+ * @param {string}  username        - Username of the user to insert. Default 'genericuser'
+ * @param {string}  password        - Password of the user to insert. Default 'genericpassword'
+ * @param {string}  email           - Email of the user to insert. Default 'generic@gmail.com'
+ * @param {boolean} isProf          - Whether the inserted user is a professor. Default false
+ * @param {boolean} verified        - If isProf = true, whether the inserted professor is verified. Default false
+ * @param {number}  lifetimeExp     - Lifetime exp of the user to insert. Default 0
+ * @param {number}  weeklyExp       - Weekly exp of the user to insert. Default 0
+ * @param {number}  dailyExp        - Daily exp of the user to insert. Default 0
+ * @param {number}  coins           - Coin balance of the user to insert. Default 0
+ * @param {boolean} isSharingStats  - Whether user is opted in to share stats to the aggregate pool. Default false
+ * @returns {Promise<number>} Inserted user ID
+ */
+const insertUser = async ({ firstName = 'Generic', lastName = 'User', username = 'genericuser', password = 'genericpassword', email = 'generic@gmail.com', isProf = false, verified = false, lifetimeExp = 0, weeklyExp = 0, dailyExp = 0, coins = 0, isSharingStats = false } = {}) => {
+
+  // Insert generic user from provided or overridden arguments
+  const [result] = await pool.query(
+    `INSERT INTO User (FIRSTNAME, LASTNAME, USERNAME, PASSWORD, EMAIL, IS_PROF, VERIFIED, LIFETIME_EXP, WEEKLY_EXP, DAILY_EXP, COINS, IS_SHARING_STATS)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [firstName, lastName, username, password, email, isProf ? 1 : 0, verified ? 1 : 0, lifetimeExp, weeklyExp, dailyExp, coins, isSharingStats ? 1 : 0]
+  );
+
+  return result.insertId;
+};
+
+/**
  * Inserts a guild with the specified parameters
  * @param {string}  name        - Name of the guild to insert. Default 'Ancient Wolves'
  * @param {number}  ownerId     - ID of user to make owner of the guild. Default null
@@ -193,6 +223,7 @@ async function verifyTestDatabase(pool)
 
 module.exports = {
   TEST_USER,
+  insertUser,
   insertGuild,
   insertPurchase,
   insertQuestion,

--- a/backend/__test__/testHelpers.js
+++ b/backend/__test__/testHelpers.js
@@ -29,6 +29,40 @@ const TEST_USER = {
   lastName: "User"
 };
 
+// Default test professor template, can be overridden for individual tests
+const TEST_PROF = {
+  email:     "testprof@ucf.edu",
+  username:  "testprofessor",
+  password:  "Testpass123!",
+  firstName: "Test",
+  lastName:  "Professor"
+};
+
+/**
+ * Inserts a Response row with the specified parameters
+ * Use this for adding deterministic test data for analytics/stats tests
+ * Does NOT trigger grading, currency awarding, or any other side effects
+ *
+ * @param {number}      userId         - User ID
+ * @param {number}      questionId     - Question ID
+ * @param {number}      pointsEarned   - Points earned. Default 0
+ * @param {number}      pointsPossible - Points possible. Default 1
+ * @param {boolean}     isCorrect      - Whether correct. Default false
+ * @param {number|null} elapsedTime    - Elapsed time in seconds. Default null
+ * @param {string}      topic          - Topic/subcategory. Default 'Arrays'
+ * @param {string}      category       - Category. Default 'Introductory Programming'
+ * @returns {Promise<number>} Inserted response ID
+ */
+const insertResponse = async (userId, questionId, { pointsEarned = 0, pointsPossible = 1, isCorrect = false, elapsedTime = null, topic = 'Arrays', category = 'Introductory Programming' } = {}) => {
+  const [result] = await pool.query(
+    `INSERT INTO Response
+     (USERID, PROBLEM_ID, POINTS_EARNED, POINTS_POSSIBLE, ISCORRECT, ELAPSED_TIME, TOPIC, CATEGORY, DATETIME)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())`,
+    [userId, questionId, pointsEarned, pointsPossible, isCorrect ? 1 : 0, elapsedTime, topic, category]
+  );
+  return result.insertId;
+};
+
 /**
  * Inserts a generic user with the specified parameters
  * NOTE: Avoid inserting multiple users with duplicate info
@@ -121,7 +155,7 @@ const insertPurchase = async (userId, itemInfo = {}, isEquipped = false) => {
 const insertQuestion = async (type, answers = [], { points = 2.00, isPublished = true, ownerId = null } = {}) => {
   const [result] = await pool.query(
     'INSERT INTO Question (QUESTION_TEXT, TYPE, SUBCATEGORY, SECTION, CATEGORY, POINTS_POSSIBLE, IS_PUBLISHED, OWNER_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-    ['Test question', type, 'Test Topic', 'A', 'Test Category', points, isPublished ? 1 : 0, ownerId]
+    ['Test question', type, 'Arrays', 'A', 'Introductory Programming', points, isPublished ? 1 : 0, ownerId]
   );
   const questionId = result.insertId;
 
@@ -146,8 +180,8 @@ const submitAndFetch = async (questionId, userAnswer, token) => {
     .send({
       problem_id: questionId,
       userAnswer,
-      category:   'Test Category',
-      topic:      'Test Topic',
+      category:   'Introductory Programming',
+      topic:      'Arrays',
     });
 
   const [rows] = await pool.query(
@@ -193,6 +227,39 @@ async function getAuthToken()
 }
 
 /**
+ * Get a JWT auth token for the test professor
+ * Creates the professor if it doesn't exist, then logs in.
+ * Professor is inserted as verified so login is permitted.
+ *
+ * @returns {Promise<string>} - JWT token
+ */
+async function getProfAuthToken()
+{
+  const hashedPass = await bcrypt.hash(TEST_PROF.password, 10);
+
+  await pool.query(
+    `INSERT INTO User (USERNAME, EMAIL, PASSWORD, FIRSTNAME, LASTNAME, IS_PROF, VERIFIED)
+     VALUES (?, ?, ?, ?, ?, 1, 1)
+     ON DUPLICATE KEY UPDATE PASSWORD = VALUES(PASSWORD)`,
+    [TEST_PROF.username, TEST_PROF.email, hashedPass, TEST_PROF.firstName, TEST_PROF.lastName]
+  );
+
+  const res = await request(app)
+    .post("/api/auth/login")
+    .send({
+      username: TEST_PROF.username,
+      password: TEST_PROF.password
+    });
+
+  if (!res.body.token)
+  {
+    throw new Error("Failed to get prof auth token: " + JSON.stringify(res.body));
+  }
+
+  return res.body.token;
+}
+
+/**
  * Verifies connection to test database, exits if wrong database
  * !!! CALL THIS IN beforeAll() OF EVERY TEST FILE !!!
  * 
@@ -223,11 +290,14 @@ async function verifyTestDatabase(pool)
 
 module.exports = {
   TEST_USER,
+  TEST_PROF,
+  insertResponse,
   insertUser,
   insertGuild,
   insertPurchase,
   insertQuestion,
   submitAndFetch,
   getAuthToken,
+  getProfAuthToken,
   verifyTestDatabase
 };

--- a/backend/__test__/testHelpers.js
+++ b/backend/__test__/testHelpers.js
@@ -30,6 +30,34 @@ const TEST_USER = {
 };
 
 /**
+ * Inserts a guild with the specified parameters
+ * @param {string}  name        - Name of the guild to insert. Default 'Ancient Wolves'
+ * @param {number}  ownerId     - ID of user to make owner of the guild. Default null
+ * @param {number}  lifetimeExp - Lifetime exp of the guild. Default 0
+ * @param {number}  weeklyExp   - Weekly exp of the guild. Default 0
+ * @param {number}  coins       - Total coin bank of the guild. Default 0
+ * @param {number}  dailyExp    - Daily exp of the guild. Default 0
+ * @param {boolean} isOpen      - Whether guild is accepting requests to join. Default false
+ * @returns {Promise<number>} Inserted guild ID
+ */
+const insertGuild = async ({ name = 'Ancient Wolves', ownerId = null, lifetimeExp = 0, weeklyExp = 0, coins = 0, dailyExp = 0, isOpen = false } = {}) => {
+
+  // OWNER_ID can't be null, you actually have to give that
+  if (ownerId === null)
+  {
+    throw new Error('insertGuild() requires an ownerId');
+  }
+
+  const [result] = await pool.query(
+    `INSERT INTO Guild (NAME, OWNER_ID, LIFETIME_EXP, WEEKLY_EXP, COINS, DAILY_EXP, IS_OPEN)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [name, ownerId, lifetimeExp, weeklyExp, coins, dailyExp, isOpen]
+  );
+
+  return result.insertId;
+};
+
+/**
  * Inserts a store item and purchase for it, optionally equips
  * @param {number} userId      - User to purchase for
  * @param {Object} itemInfo    - Optional store item info, default fields used otherwise
@@ -165,6 +193,7 @@ async function verifyTestDatabase(pool)
 
 module.exports = {
   TEST_USER,
+  insertGuild,
   insertPurchase,
   insertQuestion,
   submitAndFetch,

--- a/backend/__test__/testHelpers.js
+++ b/backend/__test__/testHelpers.js
@@ -122,6 +122,40 @@ const insertGuild = async ({ name = 'Ancient Wolves', ownerId = null, lifetimeEx
 };
 
 /**
+ * Inserts a guild AND its owner's GuildMember row atomically
+ * Use this instead of insertGuild when you need the owner to
+ * pass assertGuildRole checks.
+ *
+ * @param {number} ownerId  - User ID of the guild owner
+ * @param {Object} options  - Same options as insertGuild
+ * @returns {Promise<number>} Inserted guild ID
+ */
+const insertGuildWithOwner = async (ownerId, options = {}) => {
+  const guildId = await insertGuild({ ...options, ownerId });
+  await pool.query(
+    'INSERT INTO GuildMember (USER_ID, GUILD_ID, ROLE) VALUES (?, ?, ?)',
+    [ownerId, guildId, 'Owner']
+  );
+  return guildId;
+};
+
+/**
+ * Inserts a GuildMember row directly.
+ * Use for adding membership state in guild tests.
+ *
+ * @param {number} userId  - User ID
+ * @param {number} guildId - Guild ID
+ * @param {string} role    - 'Member' | 'Officer' | 'Owner'
+ * @returns {Promise<void>}
+ */
+const insertGuildMember = async (userId, guildId, role = 'Member') => {
+  await pool.query(
+    'INSERT INTO GuildMember (USER_ID, GUILD_ID, ROLE) VALUES (?, ?, ?)',
+    [userId, guildId, role]
+  );
+};
+
+/**
  * Inserts a store item and purchase for it, optionally equips
  * @param {number} userId      - User to purchase for
  * @param {Object} itemInfo    - Optional store item info, default fields used otherwise
@@ -294,6 +328,8 @@ module.exports = {
   insertResponse,
   insertUser,
   insertGuild,
+  insertGuildWithOwner,
+  insertGuildMember,
   insertPurchase,
   insertQuestion,
   submitAndFetch,

--- a/backend/__test__/user.test.js
+++ b/backend/__test__/user.test.js
@@ -18,7 +18,7 @@
 
 const request = require('supertest');
 const { app, pool } = require('../server');
-const { TEST_USER, getAuthToken, verifyTestDatabase, insertPurchase } = require('./testHelpers');
+const { TEST_USER, getAuthToken, verifyTestDatabase, insertPurchase, insertUser } = require('./testHelpers');
 const { ITEM_TYPES, EQUIP_LIMITS } = require('../../shared/itemConfig');
 
 // Mock Discord webhook
@@ -573,6 +573,161 @@ describe('GET /api/users/:id/purchases', () => {
   test('401 - no auth token', async () => {
     const res = await request(app)
       .get(`/api/users/${userId}/purchases`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test user following
+describe('POST /api/users/:id/follow', () => {
+
+  test('200 - successfully follows existing, currently unfollowed user', async () => {
+    // Insert generic user to follow
+    const followeeId = await insertUser();
+
+    // Follow
+    const res = await request(app)
+      .post(`/api/users/${followeeId}/follow`)
+      .set('Authorization', `Bearer ${token}`);
+
+    // Verify successful follow and creation of the following relationship
+    expect(res.status).toBe(200);
+    const [follows] = await pool.query(
+      'SELECT FOLLOWER_ID, FOLLOWING_ID FROM Follower WHERE FOLLOWER_ID = ? AND FOLLOWING_ID = ?',
+      [userId, followeeId]
+    );
+    expect(follows.length).toBe(1);
+
+    // Cleanup generic user we inserted (cascades to follow)
+    await pool.query('DELETE FROM User WHERE ID = ?', [followeeId]);
+  });
+
+  test('400 - cannot follow a user that you are already following', async () => {
+    // Insert generic user to follow
+    const followeeId = await insertUser();
+
+    // Insert following relationship
+    await pool.query(
+      'INSERT INTO Follower (FOLLOWER_ID, FOLLOWING_ID) VALUES (?, ?)',
+      [userId, followeeId]
+    );
+
+    // Try to follow again
+    const res = await request(app)
+      .post(`/api/users/${followeeId}/follow`)
+      .set('Authorization', `Bearer ${token}`);
+
+    // Failed
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('User is already followed.');
+
+    // Cleanup generic user we inserted (cascades to follow)
+    await pool.query('DELETE FROM User WHERE ID = ?', [followeeId]);
+  });
+
+  test('400 - cannot follow invalid user ID', async () => {
+    const res = await request(app)
+      .post('/api/users/abc/follow')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Invalid user ID');
+  });
+
+  test('400 - user cannot follow themselves', async () => {
+    const res = await request(app)
+      .post(`/api/users/${userId}/follow`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('User cannot follow themselves.');
+  });
+
+  test('404 - cannot follow non-existent user ID', async () => {
+    const res = await request(app)
+      .post(`/api/users/999/follow`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('User not found');
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .post(`/api/users/999/follow`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test user unfollowing
+describe('DELETE /api/users/:id/follow', () => {
+
+  test('200 - successfully unfollows existing, currently followed user', async () => {
+    // Insert generic user to follow
+    const followeeId = await insertUser();
+
+    // Insert follow relationship
+    await pool.query(
+      'INSERT INTO Follower (FOLLOWER_ID, FOLLOWING_ID) VALUES (?, ?)',
+      [userId, followeeId]
+    );
+
+    // Now unfollow
+    const res = await request(app)
+      .delete(`/api/users/${followeeId}/follow`)
+      .set('Authorization', `Bearer ${token}`);
+
+    // Verify successful unfollow and deletion of the following relationship
+    expect(res.status).toBe(200);
+    const [unfollows] = await pool.query(
+      'SELECT FOLLOWER_ID, FOLLOWING_ID FROM Follower WHERE FOLLOWER_ID = ? AND FOLLOWING_ID = ?',
+      [userId, followeeId]
+    );
+    expect(unfollows.length).toBe(0);
+
+    // Cleanup generic user we inserted (cascades to follow)
+    await pool.query('DELETE FROM User WHERE ID = ?', [followeeId]);
+  });
+
+  test('400 - cannot unfollow a user that you are not already following', async () => {
+    // Insert generic user, but we don't follow them
+    const followeeId = await insertUser();
+
+    // Try to unfollow
+    const res = await request(app)
+      .delete(`/api/users/${followeeId}/follow`)
+      .set('Authorization', `Bearer ${token}`);
+
+    // Failed
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('User is not followed.');
+
+    // Cleanup generic user we inserted (cascades to follow)
+    await pool.query('DELETE FROM User WHERE ID = ?', [followeeId]);
+  });
+
+  test('400 - cannot unfollow invalid user ID', async () => {
+    const res = await request(app)
+      .delete('/api/users/abc/follow')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Invalid user ID');
+  });
+
+  test('404 - cannot unfollow non-existent user ID', async () => {
+    const res = await request(app)
+      .delete(`/api/users/999/follow`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('User not found');
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .delete(`/api/users/999/follow`);
 
     expect(res.status).toBe(401);
   });

--- a/backend/__test__/user.test.js
+++ b/backend/__test__/user.test.js
@@ -891,3 +891,112 @@ describe('GET /api/users/search', () => {
     expect(res.status).toBe(401);
   });
 });
+
+// Test stats opt-in toggle
+describe('PUT /api/users/:id/stats-opt-in', () => {
+
+  test('200 - successfully enables stats sharing', async () => {
+    const res = await request(app)
+      .put(`/api/users/${userId}/stats-opt-in`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ optIn: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('optIn', true);
+
+    const [rows] = await pool.query('SELECT IS_SHARING_STATS FROM User WHERE ID = ?', [userId]);
+    expect(rows[0].IS_SHARING_STATS).toBe(1);
+  });
+
+  test('200 - successfully disables stats sharing', async () => {
+    const res = await request(app)
+      .put(`/api/users/${userId}/stats-opt-in`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ optIn: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('optIn', false);
+
+    const [rows] = await pool.query('SELECT IS_SHARING_STATS FROM User WHERE ID = ?', [userId]);
+    expect(rows[0].IS_SHARING_STATS).toBe(0);
+  });
+
+  test('200 - setting same value twice leaves it unchanged', async () => {
+    await request(app)
+      .put(`/api/users/${userId}/stats-opt-in`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ optIn: true });
+
+    // Set it true again
+    const res = await request(app)
+      .put(`/api/users/${userId}/stats-opt-in`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ optIn: true });
+
+    // Still true
+    expect(res.status).toBe(200);
+    const [rows] = await pool.query('SELECT IS_SHARING_STATS FROM User WHERE ID = ?', [userId]);
+    expect(rows[0].IS_SHARING_STATS).toBe(1);
+  });
+
+  test('400 - rejects non-boolean optIn', async () => {
+    const res = await request(app)
+      .put(`/api/users/${userId}/stats-opt-in`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ optIn: 'yes' });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('400 - rejects missing optIn field', async () => {
+    const res = await request(app)
+      .put(`/api/users/${userId}/stats-opt-in`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  test('400 - invalid user ID', async () => {
+    const res = await request(app)
+      .put('/api/users/abc/stats-opt-in')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ optIn: true });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .put(`/api/users/${userId}/stats-opt-in`)
+      .send({ optIn: true });
+
+    expect(res.status).toBe(401);
+  });
+
+  test('403 - cannot update another user', async () => {
+    const res = await request(app)
+      .put('/api/users/999999/stats-opt-in')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ optIn: true });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('404 - user not found', async () => {
+    // Delete user
+    await pool.query('DELETE FROM User WHERE ID = ?', [userId]);
+
+    const res = await request(app)
+      .put(`/api/users/${userId}/stats-opt-in`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ optIn: true });
+
+    expect(res.status).toBe(404);
+
+    // Add user back for any future tests
+    token = await getAuthToken();
+    const [rows] = await pool.query('SELECT ID FROM User WHERE EMAIL = ?', [TEST_USER.email]);
+    userId = rows[0].ID;
+  });
+});

--- a/backend/__test__/user.test.js
+++ b/backend/__test__/user.test.js
@@ -13,6 +13,7 @@
 //                 mysql2 connection pool (server.js)
 //                 testHelpers
 //                 discordWebhook (mocked)
+//                 paginationConfig (mocked)
 //
 ////////////////////////////////////////////////////////////////
 
@@ -27,6 +28,15 @@ jest.mock('../services/discordWebhook', () => ({
   sendNotification: jest.fn().mockResolvedValue(true),
   notifyUserEvent: jest.fn().mockResolvedValue(true),
   notifyError: jest.fn().mockResolvedValue(true),
+}));
+
+// Mock paginationConfig to a small page size for pagination tests
+const { PAGE_SIZES } = require('../config/paginationConfig'); 
+jest.mock('../config/paginationConfig', () => ({
+  PAGE_SIZES: {
+    LEADERBOARD: 50,
+    USER_SEARCH: 2, // So we don't have to insert a bunch of users
+  }
 }));
 
 let token;
@@ -728,6 +738,155 @@ describe('DELETE /api/users/:id/follow', () => {
   test('401 - no auth token', async () => {
     const res = await request(app)
       .delete(`/api/users/999/follow`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test user searching
+describe('GET /api/users/search', () => {
+
+  let searchUserIds = [];
+
+  beforeAll(async () => {
+    // Insert 3 users with "knight" in the username, enough to spill onto page 2 with PAGE_SIZE mocked to 2
+    searchUserIds.push(await insertUser({ username: 'knightking',  firstName: 'Arthur',   lastName: 'Pendragon', email: 'arthur@gmail.com' }));
+    searchUserIds.push(await insertUser({ username: 'knightmare',  firstName: 'Bors',     lastName: 'Ganis'    , email: 'bors@hotmail.com' }));
+    searchUserIds.push(await insertUser({ username: 'knightrider', firstName: 'Lancelot', lastName: 'Du Lac'   , email: 'lancelot@cs.com'  }));
+    searchUserIds.push(await insertUser({ username: 'roundtable',  firstName: 'Gawain',   lastName: 'Orkney'   , email: 'gawain@aol.com' }));
+  });
+
+  afterAll(async () => {
+    await pool.query(
+      `DELETE FROM User WHERE ID IN (${searchUserIds.map(() => '?').join(',')})`,
+      searchUserIds
+    );
+  });
+
+  test('200 - partial match returns matching users', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=knight')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const usernames = res.body.users.map(u => u.USERNAME);
+    expect(usernames).toContain('knightking');
+    expect(usernames).not.toContain('roundtable');
+  });
+
+  test('200 - search is case insensitive', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=KNIGHT')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const usernames = res.body.users.map(u => u.USERNAME);
+    expect(usernames).toContain('knightking');
+    expect(usernames).toContain('knightmare');
+  });
+
+  test('200 - empty username returns all users', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.users.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('200 - no username param returns all users', async () => {
+    const res = await request(app)
+      .get('/api/users/search')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.users.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('200 - no match returns empty list, not error', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=zzznomatchzzz')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.users).toHaveLength(0);
+    expect(res.body.pagination.totalUsers).toBe(0);
+    expect(res.body.pagination.totalPages).toBe(0);
+  });
+
+  test('200 - response includes expected user fields', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=knightking')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.users).toHaveLength(1);
+    const user = res.body.users[0];
+    expect(user).toHaveProperty('ID');
+    expect(user).toHaveProperty('USERNAME', 'knightking');
+    expect(user).toHaveProperty('FIRSTNAME');
+    expect(user).toHaveProperty('LASTNAME');
+  });
+
+  test('200 - does not expose sensitive fields', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=knightking')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const user = res.body.users[0];
+    expect(user).not.toHaveProperty('PASSWORD');
+    expect(user).not.toHaveProperty('EMAIL');
+    expect(user).not.toHaveProperty('COINS');
+  });
+
+  test('200 - pagination metadata present and correct on page 1', async () => {
+    // 3 knight users, page size mocked to 2
+    // So we'll have first page with 2 users and second page with 1
+    const res = await request(app)
+      .get('/api/users/search?username=knight&page=1')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('pagination');
+    expect(res.body.pagination).toHaveProperty('page', 1);
+    expect(res.body.pagination).toHaveProperty('pageSize', 2);
+    expect(res.body.pagination).toHaveProperty('totalUsers', 3);
+    expect(res.body.pagination).toHaveProperty('totalPages', 2);
+    expect(res.body.users).toHaveLength(2); // Page 1 full
+  });
+
+  test('200 - page 2 returns remaining results', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=knight&page=2')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.page).toBe(2);
+    expect(res.body.users).toHaveLength(1); // Only 1 user with "knight" left on page 2
+  });
+
+  test('200 - invalid page clamps to 1', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=knight&page=abc')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.page).toBe(1);
+  });
+
+  test('200 - out of range page clamps to last page', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=knight&page=99999')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.page).toBe(res.body.pagination.totalPages);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .get('/api/users/search?username=knight');
 
     expect(res.status).toBe(401);
   });

--- a/backend/config/guildNames.js
+++ b/backend/config/guildNames.js
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          guildNames.js
+//  Description:   Config file where word bank for generating
+//                 guild names live.
+//
+////////////////////////////////////////////////////////////////
+
+// A guild name is an adjective followed by a plural noun.
+// i.e. "Speedy Hedgehogs"
+// Feel free to add some more!
+const guildNames = {
+  adjectives: [
+    "Ancient", "Blazing", "Crazy", "Diabolical", "Deprecated", "Eternal",
+    "Fierce", "Golden", "Handy", "Iron", "Jade", "Lunar", "Mystic",
+    "Noble", "Ornate", "Powerful","Radiant", "Recursive", "Sacred",
+    "Speedy", "Twisted", "Undying", "Victorious",
+  ],
+  pluralNouns: [
+    "Academics", "Astronauts", "Bookworms", "Bishops", "Crowns",
+    "Dragons", "Diamonds", "Embers", "Fangs", "Guardians", "Hedgehogs",
+    "Iguanas", "Jesters", "Knights", "Kings", "Legions",
+    "Monsters", "Mainframes", "Networks", "Outlaws", "Phantoms",
+    "Pawns", "Queens", "Rooks", "Serpents", "Titans", "Wolves",
+  ],
+};
+
+module.exports = guildNames;

--- a/backend/config/paginationConfig.js
+++ b/backend/config/paginationConfig.js
@@ -9,9 +9,11 @@
 ////////////////////////////////////////////////////////////////
 
 const PAGE_SIZES = Object.freeze({
-  LEADERBOARD:    50, // Max number of users shown on a page of the leaderboard
-  USER_SEARCH:    20, // Max number of users shown on a page of the user search componnet
-  HISTORY_TABLE:  10, // Max number of responses shown on a page of the History Table
+  LEADERBOARD:        50, // Max number of users shown on a page of the leaderboard
+  LEADERBOARD_GUILD:  25, // Max number of guilds shown on a page of the leaderboard
+                          // less than regular leaderboard because there are fewer guilds
+  USER_SEARCH:        20, // Max number of users shown on a page of the user search componnet
+  HISTORY_TABLE:      10, // Max number of responses shown on a page of the History Table
 });
 
 module.exports = { PAGE_SIZES };

--- a/backend/config/paginationConfig.js
+++ b/backend/config/paginationConfig.js
@@ -1,0 +1,16 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          paginationConfig.js
+//  Description:   Backend pagination constants
+//
+////////////////////////////////////////////////////////////////
+
+const PAGE_SIZES = Object.freeze({
+  LEADERBOARD:  50, // Max number of users shown on a page of the leaderboard
+  USER_SEARCH:  20, // Max number of users shown on a page of the user search componnet
+});
+
+module.exports = { PAGE_SIZES };

--- a/backend/config/paginationConfig.js
+++ b/backend/config/paginationConfig.js
@@ -9,8 +9,9 @@
 ////////////////////////////////////////////////////////////////
 
 const PAGE_SIZES = Object.freeze({
-  LEADERBOARD:  50, // Max number of users shown on a page of the leaderboard
-  USER_SEARCH:  20, // Max number of users shown on a page of the user search componnet
+  LEADERBOARD:    50, // Max number of users shown on a page of the leaderboard
+  USER_SEARCH:    20, // Max number of users shown on a page of the user search componnet
+  HISTORY_TABLE:  10, // Max number of responses shown on a page of the History Table
 });
 
 module.exports = { PAGE_SIZES };

--- a/backend/controllers/codeController.js
+++ b/backend/controllers/codeController.js
@@ -136,7 +136,7 @@ const submitCode = asyncHandler(async (req, res) => {
   // Code can only be submitted by account owner
   const userId = req.user.id; // Set by authMiddleware.js
 
-  const { problemId, code, languageId, isTestRun } = req.body;
+  const { problemId, code, languageId, isTestRun, elapsedTime } = req.body;
 
   if (!problemId || !code || !languageId || code.trim().length === 0 || isTestRun === undefined)
   {
@@ -270,9 +270,10 @@ const submitCode = asyncHandler(async (req, res) => {
           POINTS_POSSIBLE,
           CATEGORY,
           TOPIC,
+          ELAPSED_TIME,
           DATETIME
         ) 
-        VALUES (?, ?, ?, FALSE, 0, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, FALSE, 0, ?, ?, ?, ?, ?)`,
         [
           userId, 
           problemId, 
@@ -280,6 +281,7 @@ const submitCode = asyncHandler(async (req, res) => {
           question.POINTS_POSSIBLE, 
           question.CATEGORY, 
           question.SUBCATEGORY,
+          elapsedTime ?? null,
           new Date()
         ]
       );
@@ -336,9 +338,10 @@ const submitCode = asyncHandler(async (req, res) => {
       POINTS_POSSIBLE,
       CATEGORY,
       TOPIC,
+      ELAPSED_TIME,
       DATETIME
     ) 
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       userId, 
       problemId, 
@@ -348,6 +351,7 @@ const submitCode = asyncHandler(async (req, res) => {
       question.POINTS_POSSIBLE, 
       question.CATEGORY, 
       question.SUBCATEGORY,
+      elapsedTime ?? null,
       new Date()
     ]
   );

--- a/backend/controllers/codeController.js
+++ b/backend/controllers/codeController.js
@@ -21,7 +21,7 @@ const {
         MAX_TEST_RUNS_PER_PROBLEM,
         getProgrammingSubmissionsRemaining,
       } = require('../config/codeLimits'); 
-const { awardCurrency } = require('../utils/currencyUtils');
+const { awardCurrency, awardGuildExp } = require('../utils/currencyUtils');
 
 /**
  * Grade test case results, calculate score
@@ -357,7 +357,9 @@ const submitCode = asyncHandler(async (req, res) => {
   );
 
   // Award currency to user (respects daily exp cap)
+  // Also award exp to user's guild if they're in one
   await awardCurrency(req.db, userId, gradingResults.pointsEarned);
+  await awardGuildExp(req.db, userId, gradingResults.pointsEarned);
 
   // Return results
   return res.status(200).json({

--- a/backend/controllers/guildController.js
+++ b/backend/controllers/guildController.js
@@ -4,18 +4,113 @@
 //  Year:          2026
 //  Author(s):     Daniel Landsman
 //  File:          guildController.js
-//  Description:   Controller functions for guild operations,
-//                 including name generation. 
+//  Description:   Controller functions for guild operations.
 //                 Requires authentication.
 //
 //  Dependencies:  mysql2 connection pool (req.db)
 //                 errorHandler
 //                 guildNames
+//                 itemConfig
+//                 guildConfig
+//                 discordWebhook
 //
 ////////////////////////////////////////////////////////////////
 
 const { asyncHandler, AppError } = require('../middleware/errorHandler');
-const guildNames = require("../config/guildNames");
+const guildNames = require('../config/guildNames');
+const { EQUIP_LIMITS } = require('../../shared/itemConfig');
+const { MAX_GUILD_SIZE } = require('../../shared/guildConfig');
+const { notifyUserEvent } = require('../services/discordWebhook');
+
+/**
+ * Helper function, asserts that the requesting user is a member of the guild
+ * and that their role is one of the allowed roles.
+ * Used throughout the file to enforce guild role permissions
+ *
+ * @param {Object}    db           - Database connection pool
+ * @param {number}    userId       - Requesting user's ID
+ * @param {number}    guildId      - Guild ID
+ * @param {string[]}  allowedRoles - Roles permitted to perform the action
+ * @param {string}    context      - Caller name for error logging
+ * @throws {AppError} 403          - If user is not a member or role not permitted
+ * @returns {Promise<string>}      - The caller's guild role
+ */
+const assertGuildRole = async (db, userId, guildId, allowedRoles, context) => {
+  const [[member]] = await db.query(
+    'SELECT ROLE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+    [userId, guildId]
+  );
+
+  if (!member)
+  {
+    throw new AppError(`[${context}] User ${userId} is not a member of guild ${guildId}`, 403, 'Forbidden');
+  }
+
+  if (!allowedRoles.includes(member.ROLE))
+  {
+    throw new AppError(`[${context}] Role ${member.ROLE} not permitted for this action`, 403, 'Forbidden');
+  }
+
+  return member.ROLE;
+};
+
+/**
+ * Helper function, verifies a guild item has been unlocked by the guild
+ * (guild coin bank has met the item's cost threshold and
+ * a GuildUnlock row exists). Analogous to assertItemOwnership.
+ *
+ * @param {Object}  db      - Database connection pool
+ * @param {number}  guildId - Guild ID
+ * @param {number}  itemId  - StoreItem ID
+ * @param {string}  context - Caller name for error logging
+ * @throws {AppError} 404   - If item doesn't exist or is not a guild item
+ * @throws {AppError} 403   - If item has not been unlocked by the guild
+ * @returns {Promise<{IS_EQUIPPED: boolean, TYPE: string}>} - GuildUnlock row
+ */
+const assertGuildItemUnlocked = async (db, guildId, itemId, context) => {
+  // Verify item exists and is a guild item
+  const [[item]] = await db.query(
+    'SELECT ID, TYPE FROM StoreItem WHERE ID = ? AND IS_GUILD_ITEM = 1',
+    [itemId]
+  );
+  if (!item)
+  {
+    throw new AppError(`[${context}] Item ${itemId} not found or not a guild item`, 404, 'Item not found');
+  }
+
+  // Check GuildUnlock row exists
+  const [[unlock]] = await db.query(
+    'SELECT IS_EQUIPPED, TYPE FROM GuildUnlock gu JOIN StoreItem si ON si.ID = gu.ITEM_ID WHERE gu.GUILD_ID = ? AND gu.ITEM_ID = ?',
+    [guildId, itemId]
+  );
+  if (!unlock)
+  {
+    throw new AppError(`[${context}] Guild ${guildId} has not unlocked item ${itemId}`, 403, 'Item not unlocked');
+  }
+
+  return unlock;
+};
+
+/**
+ * Helper function, verifies a guild exists and returns it.
+ *
+ * @param {Object}  db      - Database connection pool
+ * @param {number}  guildId - Guild ID
+ * @param {string}  context - Caller name for error logging
+ * @throws {AppError} 404   - If guild not found
+ * @returns {Promise<Object>} - Guild row
+ */
+const assertGuildExists = async (db, guildId, context) => {
+  const [[guild]] = await db.query(
+    'SELECT * FROM Guild WHERE ID = ?',
+    [guildId]
+  );
+  if (!guild)
+  {
+    throw new AppError(`[${context}] Guild ${guildId} not found`, 404, 'Guild not found');
+  }
+  return guild;
+};
 
 /**
  * @route   GET /api/guilds/name/generate
@@ -33,7 +128,7 @@ const generateGuildName = asyncHandler(async (req, res) => {
   const { adjectives, pluralNouns } = guildNames;
 
   // Verify there are names to choose from
-  if (!adjectives?.length || !pluralNouns?.length) 
+  if (!adjectives?.length || !pluralNouns?.length)
   {
     throw new AppError(`Adjectives or plural nouns list is empty`, 500, 'Guild name word bank is currently unavailable.');
   }
@@ -53,7 +148,7 @@ const generateGuildName = asyncHandler(async (req, res) => {
     for (const noun of pluralNouns)
     {
       const name = `${adj} ${noun}`;
-      if (!takenSet.has(name))
+      if (!takenSet.has(name)) 
       {
         // This combination isn't used, so it's available
         availableNames.push(name);
@@ -61,7 +156,7 @@ const generateGuildName = asyncHandler(async (req, res) => {
     }
   }
 
-  if (availableNames.length === 0) 
+  if (availableNames.length === 0)
   {
     throw new AppError('All guild names are taken, add more!', 503, 'All guild names are currently in use, come back later for more!');
   }
@@ -71,4 +166,914 @@ const generateGuildName = asyncHandler(async (req, res) => {
   return res.status(200).json({ name });
 });
 
-module.exports = { generateGuildName };
+/**
+ * @route   POST /api/guilds
+ * @desc    Create a new guild. Requesting user becomes Owner.
+ *          Atomically inserts Guild and GuildMember rows in a transaction.
+ *          User must not already be in a guild or own one.
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Missing name field
+ * @throws  {AppError} 409                 - User already in a guild, or name taken
+ * @returns {Promise<void>}                - Sends HTTP/JSON response with new guild ID
+ */
+const createGuild = asyncHandler(async (req, res) => {
+  const context = 'createGuild';
+  const userId  = req.user.id;
+  const { name } = req.body;
+
+  if (!name || !name.trim())
+  {
+    throw new AppError(`[${context}] Missing guild name`, 400, 'Guild name is required');
+  }
+
+  // User must not already be a guild member
+  const [[existingMembership]] = await req.db.query(
+    'SELECT GUILD_ID FROM GuildMember WHERE USER_ID = ?',
+    [userId]
+  );
+  if (existingMembership)
+  {
+    throw new AppError(`[${context}] User ${userId} is already in a guild`, 409, 'You are already in a guild');
+  }
+
+  // Name must be unique
+  const [[existingGuild]] = await req.db.query(
+    'SELECT ID FROM Guild WHERE NAME = ?',
+    [name]
+  );
+  if (existingGuild)
+  {
+    throw new AppError(`[${context}] Guild name already taken: ${name}`, 409, 'Guild name is already taken');
+  }
+
+  // Atomically create guild and insert owner as member
+  const conn = await req.db.getConnection();
+  try
+  {
+    await conn.beginTransaction();
+
+    const [guildResult] = await conn.query(
+      'INSERT INTO Guild (NAME, OWNER_ID) VALUES (?, ?)',
+      [name, userId]
+    );
+    const guildId = guildResult.insertId;
+
+    await conn.query(
+      'INSERT INTO GuildMember (USER_ID, GUILD_ID, ROLE) VALUES (?, ?, ?)',
+      [userId, guildId, 'Owner']
+    );
+
+    await conn.commit();
+
+    // Notify Discord and return success
+    notifyUserEvent(`Guild created: ${name} by user ${userId}`);
+    return res.status(201).json({ message: 'Guild created successfully', guildId });
+  }
+  catch (err)
+  {
+    await conn.rollback();
+    throw err;
+  }
+  finally
+  {
+    conn.release();
+  }
+});
+
+/**
+ * @route   DELETE /api/guilds/:id/leave
+ * @desc    Leave a guild. Member or Officer only.
+ *          Owners cannot leave, they must delete the guild.
+ * @access  Protected, member or officer only
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Invalid guild ID
+ * @throws  {AppError} 403                 - Owner cannot leave, or not a member
+ * @throws  {AppError} 404                 - Guild not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON confirming leave
+ */
+const leaveGuild = asyncHandler(async (req, res) => {
+  const context = 'leaveGuild';
+  const userId  = req.user.id;
+  const guildId = parseInt(req.params.id);
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+
+  // assertGuildRole also confirms membership, Owner excluded intentionally
+  await assertGuildRole(req.db, userId, guildId, ['Member', 'Officer'], context);
+
+  await req.db.query(
+    'DELETE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+    [userId, guildId]
+  );
+
+  return res.status(200).json({ message: 'Left guild successfully' });
+});
+
+/**
+ * @route   DELETE /api/guilds/:id
+ * @desc    Delete a guild. Owner only. Cascades to GuildMember and GuildEntry.
+ * @access  Protected, owner only
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 403                 - If caller is not Owner
+ * @throws  {AppError} 404                 - If guild not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON response confirming deletion
+ */
+const deleteGuild = asyncHandler(async (req, res) => {
+  const context = 'deleteGuild';
+  const userId  = req.user.id;
+  const guildId = parseInt(req.params.id);
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+  await assertGuildRole(req.db, userId, guildId, ['Owner'], context);
+
+  await req.db.query('DELETE FROM Guild WHERE ID = ?', [guildId]);
+
+  // Notify Discord and return success
+  notifyUserEvent(`Guild deleted: ID ${guildId} by user ${userId}`);
+  return res.status(200).json({ message: 'Guild deleted successfully' });
+});
+
+/**
+ * @route   GET /api/guilds/:id
+ * @desc    Get guild info alongside currently equipped guild items.
+ *          Mirrors getUserInfo structure.
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 404                 - If guild not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON response with guild info and equipped items
+ */
+const getGuildInfo = asyncHandler(async (req, res) => {
+  const context = 'getGuildInfo';
+  const guildId = parseInt(req.params.id);
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+
+  const [[guildRows], [equippedItems]] = await Promise.all([
+    req.db.query(
+      'SELECT ID, NAME, OWNER_ID, LIFETIME_EXP, WEEKLY_EXP, COINS, DAILY_EXP, ESTABLISHED, IS_OPEN FROM Guild WHERE ID = ?',
+      [guildId]
+    ),
+    req.db.query(
+      `SELECT si.ID, si.TYPE, si.COST, si.NAME
+       FROM GuildUnlock gu
+       JOIN StoreItem si ON si.ID = gu.ITEM_ID
+       WHERE gu.GUILD_ID = ? AND gu.IS_EQUIPPED = 1`,
+      [guildId]
+    )
+  ]);
+
+  guild = guildRows[0];
+
+  if (!guild)
+  {
+    throw new AppError(`[${context}] Guild ${guildId} not found`, 404, 'Guild not found');
+  }
+
+  return res.status(200).json({ guild, equippedItems });
+});
+
+/**
+ * @route   POST /api/guilds/:id/contribute
+ * @desc    Contribute coins from user balance to guild coin bank.
+ *          Atomically deducts from user and increments guild bank.
+ *          After update, auto-unlocks any guild items newly eligible by cost threshold.
+ * @access  Protected, any guild member
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Invalid amount or insufficient coins
+ * @throws  {AppError} 403                 - If caller is not a guild member
+ * @throws  {AppError} 404                 - If guild not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON with updated coin bank and newly unlocked items
+ */
+const contributeCoins = asyncHandler(async (req, res) => {
+  const context = 'contributeCoins';
+  const userId  = req.user.id;
+  const guildId = parseInt(req.params.id);
+  const { amount } = req.body;
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+
+  if (!amount || isNaN(amount) || amount <= 0)
+  {
+    throw new AppError(`[${context}] Invalid contribution amount: ${amount}`, 400, 'Amount must be a positive number');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+  await assertGuildRole(req.db, userId, guildId, ['Member', 'Officer', 'Owner'], context);
+
+  // Get user's current coin balance
+  const [[user]] = await req.db.query(
+    'SELECT COINS FROM User WHERE ID = ?',
+    [userId]
+  );
+  if (user.COINS < amount)
+  {
+    throw new AppError(`[${context}] User ${userId} has insufficient coins`, 400, 'Insufficient coins');
+  }
+
+  // Atomically deduct from user and add to guild bank
+  const conn = await req.db.getConnection();
+  try
+  {
+    await conn.beginTransaction();
+
+    await conn.query(
+      'UPDATE User SET COINS = COINS - ? WHERE ID = ?',
+      [amount, userId]
+    );
+    await conn.query(
+      'UPDATE Guild SET COINS = COINS + ? WHERE ID = ?',
+      [amount, guildId]
+    );
+
+    await conn.commit();
+  }
+  catch (err)
+  {
+    await conn.rollback();
+    throw err;
+  }
+  finally
+  {
+    conn.release();
+  }
+
+  // Get updated coin bank total
+  const [[updatedGuild]] = await req.db.query(
+    'SELECT COINS FROM Guild WHERE ID = ?',
+    [guildId]
+  );
+  const coinBank = updatedGuild.COINS;
+
+  // Get all guild items not yet unlocked by this guild
+  const [lockedItems] = await req.db.query(
+    `SELECT si.ID, si.COST, si.NAME, si.TYPE
+     FROM StoreItem si
+     WHERE si.IS_GUILD_ITEM = 1
+     AND si.ID NOT IN (
+       SELECT ITEM_ID FROM GuildUnlock WHERE GUILD_ID = ?
+     )`,
+    [guildId]
+  );
+
+  // Auto-unlock any items whose cost threshold is now met
+  const newlyUnlocked = [];
+  for (const item of lockedItems)
+  {
+    if (coinBank >= item.COST)
+    {
+      await req.db.query(
+        'INSERT INTO GuildUnlock (GUILD_ID, ITEM_ID, IS_EQUIPPED) VALUES (?, ?, 0)',
+        [guildId, item.ID]
+      );
+      newlyUnlocked.push({ id: item.ID, name: item.NAME, type: item.TYPE });
+    }
+  }
+
+  return res.status(200).json({
+    message:       'Contribution successful',
+    coinBank,
+    newlyUnlocked,
+  });
+});
+
+/**
+ * @route   DELETE /api/guilds/:id/members/:userId
+ * @desc    Kick a member from the guild.
+ *          Owner can kick anyone except themselves.
+ *          Officer can kick Members only, not other Officers or Owner.
+ * @access  Protected, officer or owner
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Owner cannot kick themselves
+ * @throws  {AppError} 403                 - Insufficient role to kick target
+ * @throws  {AppError} 404                 - Guild or target member not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON confirming kick
+ */
+const kickMember = asyncHandler(async (req, res) => {
+  const context  = 'kickMember';
+  const callerId = req.user.id;
+  const guildId  = parseInt(req.params.id);
+  const targetId = parseInt(req.params.userId);
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+  if (isNaN(targetId) || targetId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid user ID: ${req.params.userId}`, 400, 'Invalid user ID');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+  const callerRole = await assertGuildRole(req.db, callerId, guildId, ['Officer', 'Owner'], context);
+
+  // Owner cannot kick themselves, they must delete the guild
+  if (callerRole === 'Owner' && callerId === targetId)
+  {
+    throw new AppError(`[${context}] Owner cannot kick themselves`, 400, 'Owner cannot kick themselves. Delete the guild instead.');
+  }
+
+  // Get target's role
+  const [[target]] = await req.db.query(
+    'SELECT ROLE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+    [targetId, guildId]
+  );
+  if (!target)
+  {
+    throw new AppError(`[${context}] Target user ${targetId} is not a member of guild ${guildId}`, 404, 'Member not found');
+  }
+
+  // Officers can only kick Members, not other Officers or Owner
+  if (callerRole === 'Officer' && target.ROLE !== 'Member')
+  {
+    throw new AppError(`[${context}] Officer cannot kick ${target.ROLE}`, 403, 'Forbidden');
+  }
+
+  await req.db.query(
+    'DELETE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+    [targetId, guildId]
+  );
+
+  return res.status(200).json({ message: 'Member kicked successfully' });
+});
+
+/**
+ * @route   PATCH /api/guilds/:id/members/:userId/role
+ * @desc    Promote or demote a guild member.
+ *          Owner can promote Members to Officer and demote Officers to Member.
+ *          Officer can promote Members to Officer only, cannot demote.
+ * @access  Protected, officer or owner
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Invalid new role or invalid IDs
+ * @throws  {AppError} 403                 - Insufficient role to perform change
+ * @throws  {AppError} 404                 - Guild or target member not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON confirming role change
+ */
+const updateMemberRole = asyncHandler(async (req, res) => {
+  const context   = 'updateMemberRole';
+  const callerId  = req.user.id;
+  const guildId   = parseInt(req.params.id);
+  const targetId  = parseInt(req.params.userId);
+  const { newRole } = req.body;
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+  if (isNaN(targetId) || targetId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid user ID: ${req.params.userId}`, 400, 'Invalid user ID');
+  }
+  if (!['Member', 'Officer'].includes(newRole))
+  {
+    throw new AppError(`[${context}] Invalid role: ${newRole}`, 400, 'Role must be Member or Officer');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+  const callerRole = await assertGuildRole(req.db, callerId, guildId, ['Officer', 'Owner'], context);
+
+  const [[target]] = await req.db.query(
+    'SELECT ROLE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+    [targetId, guildId]
+  );
+  if (!target)
+  {
+    throw new AppError(`[${context}] Target ${targetId} is not a member of guild ${guildId}`, 404, 'Member not found');
+  }
+
+  // Officers can only promote Members to Officer, cannot demote
+  if (callerRole === 'Officer')
+  {
+    if (target.ROLE !== 'Member' || newRole !== 'Officer')
+    {
+      throw new AppError(`[${context}] Officer can only promote Members to Officer`, 403, 'Forbidden');
+    }
+  }
+
+  // Owner cannot be demoted via this endpoint
+  if (target.ROLE === 'Owner')
+  {
+    throw new AppError(`[${context}] Cannot change Owner role`, 403, 'Forbidden');
+  }
+
+  await req.db.query(
+    'UPDATE GuildMember SET ROLE = ? WHERE USER_ID = ? AND GUILD_ID = ?',
+    [newRole, targetId, guildId]
+  );
+
+  return res.status(200).json({ message: `Member role updated to ${newRole}` });
+});
+
+/**
+ * @route   PUT /api/guilds/:id/equip
+ * @desc    Equip an unlocked guild item. Officer or Owner only.
+ *          Auto-swaps for item types with equip limit of 1.
+ *          Returns 409 if equip limit exceeded for types with limit > 1.
+ * @access  Protected, officer or owner
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Item already equipped or invalid IDs
+ * @throws  {AppError} 403                 - Item not unlocked or insufficient role
+ * @throws  {AppError} 404                 - Guild or item not found
+ * @throws  {AppError} 409                 - Equip limit reached for item type
+ * @returns {Promise<void>}                - Sends HTTP/JSON confirming equip
+ */
+const equipGuildItem = asyncHandler(async (req, res) => {
+  const context = 'equipGuildItem';
+  const userId  = req.user.id;
+  const guildId = parseInt(req.params.id);
+  const { itemId } = req.body;
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+  await assertGuildRole(req.db, userId, guildId, ['Officer', 'Owner'], context);
+
+  const { IS_EQUIPPED: isEquipped, TYPE: itemType } = await assertGuildItemUnlocked(req.db, guildId, itemId, context);
+
+  if (isEquipped)
+  {
+    throw new AppError(`[${context}] Item ${itemId} is already equipped`, 400, 'Item is already equipped');
+  }
+
+  // Check equip limit for this item type
+  const limit = EQUIP_LIMITS[itemType];
+  if (limit !== undefined)
+  {
+    const [[{ count }]] = await req.db.query(
+      `SELECT COUNT(*) AS count
+       FROM GuildUnlock gu
+       JOIN StoreItem si ON si.ID = gu.ITEM_ID
+       WHERE gu.GUILD_ID = ? AND si.TYPE = ? AND gu.IS_EQUIPPED = 1`,
+      [guildId, itemType]
+    );
+
+    if (count >= limit)
+    {
+      if (limit === 1)
+      {
+        // Auto-swap: unequip current item of this type
+        await req.db.query(
+          `UPDATE GuildUnlock gu
+           JOIN StoreItem si ON si.ID = gu.ITEM_ID
+           SET gu.IS_EQUIPPED = 0
+           WHERE gu.GUILD_ID = ? AND si.TYPE = ? AND gu.IS_EQUIPPED = 1`,
+          [guildId, itemType]
+        );
+      }
+      else
+      {
+        throw new AppError(
+          `[${context}] Guild ${guildId} has reached equip limit for type ${itemType}`,
+          409,
+          `Equip limit reached for ${itemType} (max ${limit})`
+        );
+      }
+    }
+  }
+
+  await req.db.query(
+    'UPDATE GuildUnlock SET IS_EQUIPPED = 1 WHERE GUILD_ID = ? AND ITEM_ID = ?',
+    [guildId, itemId]
+  );
+
+  return res.status(200).json({ message: 'Item equipped successfully' });
+});
+
+/**
+ * @route   PUT /api/guilds/:id/unequip
+ * @desc    Unequip an equipped guild item. Officer or Owner only.
+ * @access  Protected, officer or owner
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Item not equipped or invalid IDs
+ * @throws  {AppError} 403                 - Item not unlocked or insufficient role
+ * @throws  {AppError} 404                 - Guild or item not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON confirming unequip
+ */
+const unequipGuildItem = asyncHandler(async (req, res) => {
+  const context = 'unequipGuildItem';
+  const userId  = req.user.id;
+  const guildId = parseInt(req.params.id);
+  const { itemId } = req.body;
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+  await assertGuildRole(req.db, userId, guildId, ['Officer', 'Owner'], context);
+
+  const { IS_EQUIPPED: isEquipped } = await assertGuildItemUnlocked(req.db, guildId, itemId, context);
+
+  if (!isEquipped)
+  {
+    throw new AppError(`[${context}] Item ${itemId} is not equipped`, 400, 'Item is not equipped');
+  }
+
+  await req.db.query(
+    'UPDATE GuildUnlock SET IS_EQUIPPED = 0 WHERE GUILD_ID = ? AND ITEM_ID = ?',
+    [guildId, itemId]
+  );
+
+  return res.status(200).json({ message: 'Item unequipped successfully' });
+});
+
+/**
+ * @route   POST /api/guilds/:id/invite
+ * @desc    Invite a user to the guild. Officer or Owner only.
+ *          Target must not already be a member of this guild.
+ * @access  Protected, officer or owner
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Target already a member or invalid IDs
+ * @throws  {AppError} 403                 - Insufficient role
+ * @throws  {AppError} 404                 - Guild or target user not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON confirming invite sent
+ */
+const inviteUser = asyncHandler(async (req, res) => {
+  const context  = 'inviteUser';
+  const callerId = req.user.id;
+  const guildId  = parseInt(req.params.id);
+  const { targetUserId } = req.body;
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+  if (!targetUserId || isNaN(targetUserId) || targetUserId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid target user ID: ${targetUserId}`, 400, 'Invalid user ID');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+  await assertGuildRole(req.db, callerId, guildId, ['Officer', 'Owner'], context);
+
+  // Verify target user exists
+  const [[targetUser]] = await req.db.query(
+    'SELECT ID FROM User WHERE ID = ?',
+    [targetUserId]
+  );
+  if (!targetUser)
+  {
+    throw new AppError(`[${context}] Target user ${targetUserId} not found`, 404, 'User not found');
+  }
+
+  // Target must not already be a member
+  const [[existingMember]] = await req.db.query(
+    'SELECT USER_ID FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+    [targetUserId, guildId]
+  );
+  if (existingMember)
+  {
+    throw new AppError(`[${context}] User ${targetUserId} is already a member of guild ${guildId}`, 400, 'User is already a member');
+  }
+
+  // IGNORE means if invite already exists this is a no-op rather than an error
+  await req.db.query(
+    'INSERT IGNORE INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, ?)',
+    [targetUserId, guildId, 'Invite']
+  );
+
+  return res.status(200).json({ message: 'Invite sent successfully' });
+});
+
+/**
+ * @route   POST /api/guilds/:id/request
+ * @desc    Request to join a guild, can be done by any authenticated user
+ *          User must not already be a member of this guild
+ *          Guild owners cannot request to join another guild,
+ *          they must delete their guild first.
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Already a member of this guild
+ * @throws  {AppError} 409                 - Caller owns a guild (distinct from 403)
+ * @throws  {AppError} 404                 - Guild not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON confirming request sent
+ */
+const requestToJoin = asyncHandler(async (req, res) => {
+  const context = 'requestToJoin';
+  const userId  = req.user.id;
+  const guildId = parseInt(req.params.id);
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+
+  const guild = await assertGuildExists(req.db, guildId, context);
+
+  // Block join requests if guild is not open
+  if (!guild.IS_OPEN)
+  {
+    throw new AppError(
+      `[${context}] Guild ${guildId} is not open to join requests`,
+      403,
+      'This guild is not accepting join requests'
+    );
+  }
+
+  // Block guild owners, they must delete their guild first
+  const [[ownedGuild]] = await req.db.query(
+    'SELECT ID FROM Guild WHERE OWNER_ID = ?',
+    [userId]
+  );
+  if (ownedGuild)
+  {
+    throw new AppError(
+      `[${context}] User ${userId} owns a guild and cannot request to join another`,
+      409,
+      'You must delete your guild before joining another'
+    );
+  }
+
+  // Block if already a member of this guild
+  const [[existingMember]] = await req.db.query(
+    'SELECT USER_ID FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+    [userId, guildId]
+  );
+  if (existingMember)
+  {
+    throw new AppError(`[${context}] User ${userId} is already a member of guild ${guildId}`, 400, 'You are already a member of this guild');
+  }
+
+  await req.db.query(
+    'INSERT IGNORE INTO GuildEntry (USER_ID, GUILD_ID, TYPE) VALUES (?, ?, ?)',
+    [userId, guildId, 'Request']
+  );
+
+  return res.status(200).json({ message: 'Join request sent successfully' });
+});
+
+/**
+ * @route   PATCH /api/guilds/:id/entry/:userId
+ * @desc    Accept or reject a guild entry (invite or join request).
+ *          For INVITE: accepting party is the invitee (req.user).
+ *          For REQUEST: accepting party is Officer or Owner.
+ *          On rejection: GuildEntry row deleted.
+ *          On acceptance: GuildEntry deleted and GuildMember inserted atomically.
+ * 
+ *          Handles three membership state transitions:
+ *            - No guild: inserts GuildMember directly
+ *            - Member/Officer of another guild: returns flag for frontend confirmation;
+ *              if confirmed, old membership deleted and new one inserted atomically
+ *            - Owner of another guild: rejected with 409
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Invalid IDs or action
+ * @throws  {AppError} 403                 - Not authorized to act on this entry
+ * @throws  {AppError} 404                 - Guild, entry, or user not found
+ * @throws  {AppError} 409                 - Target owns another guild, or guild at max size
+ * @returns {Promise<void>}                - Sends HTTP/JSON with result
+ */
+const resolveEntry = asyncHandler(async (req, res) => {
+  const context      = 'resolveEntry';
+  const callerId     = req.user.id;
+  const guildId      = parseInt(req.params.id);
+  const targetUserId = parseInt(req.params.userId);
+  const { action, confirmLeave } = req.body; // action: 'accept' | 'reject'
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+  if (isNaN(targetUserId) || targetUserId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid user ID: ${req.params.userId}`, 400, 'Invalid user ID');
+  }
+  if (!['accept', 'reject'].includes(action))
+  {
+    throw new AppError(`[${context}] Invalid action: ${action}`, 400, 'Action must be accept or reject');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+
+  // Fetch the entry
+  const [[entry]] = await req.db.query(
+    'SELECT TYPE FROM GuildEntry WHERE USER_ID = ? AND GUILD_ID = ?',
+    [targetUserId, guildId]
+  );
+  if (!entry)
+  {
+    throw new AppError(`[${context}] No entry found for user ${targetUserId} in guild ${guildId}`, 404, 'Entry not found');
+  }
+
+  // for Invite, caller must be the invitee
+  // for Request, caller must be Officer or Owner
+  if (entry.TYPE === 'Invite')
+  {
+    if (callerId !== targetUserId)
+    {
+      throw new AppError(`[${context}] Only the invitee can accept/reject an invite`, 403, 'Forbidden');
+    }
+  }
+  else // Request
+  {
+    await assertGuildRole(req.db, callerId, guildId, ['Officer', 'Owner'], context);
+  }
+
+  // Rejection: just delete the entry
+  if (action === 'reject')
+  {
+    await req.db.query(
+      'DELETE FROM GuildEntry WHERE USER_ID = ? AND GUILD_ID = ?',
+      [targetUserId, guildId]
+    );
+    return res.status(200).json({ message: 'Entry rejected successfully' });
+  }
+
+  // Acceptance: check guild size cap
+  const [[{ memberCount }]] = await req.db.query(
+    'SELECT COUNT(*) AS memberCount FROM GuildMember WHERE GUILD_ID = ?',
+    [guildId]
+  );
+  if (memberCount >= MAX_GUILD_SIZE)
+  {
+    throw new AppError(`[${context}] Guild ${guildId} is at max size`, 409, 'Guild is full');
+  }
+
+  // Check target's current membership state
+  const [[existingMembership]] = await req.db.query(
+    'SELECT GUILD_ID FROM GuildMember WHERE USER_ID = ?',
+    [targetUserId]
+  );
+
+  // Block owners of another guild
+  const [[ownedGuild]] = await req.db.query(
+    'SELECT ID FROM Guild WHERE OWNER_ID = ?',
+    [targetUserId]
+  );
+  if (ownedGuild)
+  {
+    throw new AppError(
+      `[${context}] User ${targetUserId} owns a guild and cannot join another`,
+      409,
+      'User must delete their guild before joining another'
+    );
+  }
+
+  // If target is in another guild, require frontend confirmation before leaving
+  if (existingMembership && !confirmLeave)
+  {
+    return res.status(200).json({
+      requiresConfirmation: true,
+      message:              'User is already a member of another guild. Set confirmLeave: true to proceed.',
+    });
+  }
+
+  // Atomically handle membership transition and accept entry
+  const conn = await req.db.getConnection();
+  try
+  {
+    await conn.beginTransaction();
+
+    // Remove from current guild if applicable
+    if (existingMembership)
+    {
+      await conn.query(
+        'DELETE FROM GuildMember WHERE USER_ID = ?',
+        [targetUserId]
+      );
+    }
+
+    // Delete the entry and insert new membership
+    await conn.query(
+      'DELETE FROM GuildEntry WHERE USER_ID = ? AND GUILD_ID = ?',
+      [targetUserId, guildId]
+    );
+    await conn.query(
+      'INSERT INTO GuildMember (USER_ID, GUILD_ID, ROLE) VALUES (?, ?, ?)',
+      [targetUserId, guildId, 'Member']
+    );
+
+    await conn.commit();
+  }
+  catch (err)
+  {
+    await conn.rollback();
+    throw err;
+  }
+  finally
+  {
+    conn.release();
+  }
+
+  return res.status(200).json({ message: 'Entry accepted, user is now a guild member' });
+});
+
+/**
+ * @route   GET /api/users/me/guild-invites
+ * @desc    Get all pending guild invites for the current user.
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>}                - Sends HTTP/JSON with pending invites
+ */
+const getMyInvites = asyncHandler(async (req, res) => {
+  const userId = req.user.id;
+
+  const [invites] = await req.db.query(
+    `SELECT ge.GUILD_ID, g.NAME AS guildName, g.OWNER_ID
+     FROM GuildEntry ge
+     JOIN Guild g ON g.ID = ge.GUILD_ID
+     WHERE ge.USER_ID = ? AND ge.TYPE = 'Invite'`,
+    [userId]
+  );
+
+  return res.status(200).json({ invites });
+});
+
+/**
+ * @route   GET /api/guilds/:id/requests
+ * @desc    Get all pending join requests for a guild. Officer or Owner only.
+ * @access  Protected, officer or owner
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 403                 - Insufficient role
+ * @throws  {AppError} 404                 - Guild not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON with pending requests
+ */
+const getGuildRequests = asyncHandler(async (req, res) => {
+  const context = 'getGuildRequests';
+  const userId  = req.user.id;
+  const guildId = parseInt(req.params.id);
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+  await assertGuildRole(req.db, userId, guildId, ['Officer', 'Owner'], context);
+
+  const [requests] = await req.db.query(
+    `SELECT ge.USER_ID, u.USERNAME, u.FIRSTNAME, u.LASTNAME
+     FROM GuildEntry ge
+     JOIN User u ON u.ID = ge.USER_ID
+     WHERE ge.GUILD_ID = ? AND ge.TYPE = 'Request'`,
+    [guildId]
+  );
+
+  return res.status(200).json({ requests });
+});
+
+module.exports = {
+  generateGuildName,
+  createGuild,
+  leaveGuild,
+  deleteGuild,
+  getGuildInfo,
+  contributeCoins,
+  kickMember,
+  updateMemberRole,
+  equipGuildItem,
+  unequipGuildItem,
+  inviteUser,
+  requestToJoin,
+  resolveEntry,
+  getMyInvites,
+  getGuildRequests,
+};

--- a/backend/controllers/guildController.js
+++ b/backend/controllers/guildController.js
@@ -229,7 +229,7 @@ const createGuild = asyncHandler(async (req, res) => {
     await conn.commit();
 
     // Notify Discord and return success
-    notifyUserEvent(`Guild created: ${name} by user ${userId}`);
+    notifyUserEvent(`Guild created: ${name} (ID ${guildId}) by user ${userId}`);
     return res.status(201).json({ message: 'Guild created successfully', guildId });
   }
   catch (err)
@@ -300,13 +300,13 @@ const deleteGuild = asyncHandler(async (req, res) => {
     throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
   }
 
-  await assertGuildExists(req.db, guildId, context);
+  const guild = await assertGuildExists(req.db, guildId, context);
   await assertGuildRole(req.db, userId, guildId, ['Owner'], context);
 
   await req.db.query('DELETE FROM Guild WHERE ID = ?', [guildId]);
 
   // Notify Discord and return success
-  notifyUserEvent(`Guild deleted: ID ${guildId} by user ${userId}`);
+  notifyUserEvent(`Guild deleted: ${guild.NAME} (ID ${guildId}) by user ${userId}`);
   return res.status(200).json({ message: 'Guild deleted successfully' });
 });
 
@@ -330,7 +330,7 @@ const getGuildInfo = asyncHandler(async (req, res) => {
     throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
   }
 
-  const [[guildRows], [equippedItems]] = await Promise.all([
+  const [[guildRows], [equippedItems], [members], [unlockedItems]] = await Promise.all([
     req.db.query(
       'SELECT ID, NAME, OWNER_ID, LIFETIME_EXP, WEEKLY_EXP, COINS, DAILY_EXP, ESTABLISHED, IS_OPEN FROM Guild WHERE ID = ?',
       [guildId]
@@ -341,7 +341,22 @@ const getGuildInfo = asyncHandler(async (req, res) => {
        JOIN StoreItem si ON si.ID = gu.ITEM_ID
        WHERE gu.GUILD_ID = ? AND gu.IS_EQUIPPED = 1`,
       [guildId]
-    )
+    ),
+    req.db.query(
+      `SELECT u.ID, u.USERNAME, u.FIRSTNAME, u.LASTNAME, gm.ROLE, gm.COINS_CONTRIBUTED, gm.JOINED
+      FROM GuildMember gm
+      JOIN User u ON u.ID = gm.USER_ID
+      WHERE gm.GUILD_ID = ?
+      ORDER BY FIELD(gm.ROLE, 'Owner', 'Officer', 'Member'), u.USERNAME ASC`,
+      [guildId]
+    ),
+    req.db.query(
+      `SELECT si.ID, si.TYPE, si.COST, si.NAME, gu.IS_EQUIPPED
+      FROM GuildUnlock gu
+      JOIN StoreItem si ON si.ID = gu.ITEM_ID
+      WHERE gu.GUILD_ID = ?`,
+      [guildId]
+    ),
   ]);
 
   guild = guildRows[0];
@@ -351,7 +366,7 @@ const getGuildInfo = asyncHandler(async (req, res) => {
     throw new AppError(`[${context}] Guild ${guildId} not found`, 404, 'Guild not found');
   }
 
-  return res.status(200).json({ guild, equippedItems });
+  return res.status(200).json({ guild, equippedItems, members, unlockedItems });
 });
 
 /**
@@ -410,6 +425,10 @@ const contributeCoins = asyncHandler(async (req, res) => {
     await conn.query(
       'UPDATE Guild SET COINS = COINS + ? WHERE ID = ?',
       [amount, guildId]
+    );
+    await conn.query(
+      'UPDATE GuildMember SET COINS_CONTRIBUTED = COINS_CONTRIBUTED + ? WHERE USER_ID = ? AND GUILD_ID = ?',
+      [amount, userId, guildId]
     );
 
     await conn.commit();
@@ -1060,6 +1079,48 @@ const getGuildRequests = asyncHandler(async (req, res) => {
   return res.status(200).json({ requests });
 });
 
+/**
+ * @route   PATCH /api/guilds/:id/open
+ * @desc    Toggle guild open/closed status for join requests.
+ *          Officer or Owner only.
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Invalid guild ID or isOpen not a boolean
+ * @throws  {AppError} 403                 - Insufficient role
+ * @throws  {AppError} 404                 - Guild not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON with new open state
+ */
+const updateGuildOpen = asyncHandler(async (req, res) => {
+  const context = 'updateGuildOpen';
+  const userId  = req.user.id;
+  const guildId = parseInt(req.params.id);
+  const { isOpen } = req.body;
+
+  if (isNaN(guildId) || guildId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid guild ID: ${req.params.id}`, 400, 'Invalid guild ID');
+  }
+
+  if (typeof isOpen !== 'boolean')
+  {
+    throw new AppError(`[${context}] Invalid isOpen value: ${isOpen}`, 400, 'isOpen must be a boolean');
+  }
+
+  await assertGuildExists(req.db, guildId, context);
+  await assertGuildRole(req.db, userId, guildId, ['Officer', 'Owner'], context);
+
+  await req.db.query(
+    'UPDATE Guild SET IS_OPEN = ? WHERE ID = ?',
+    [isOpen ? 1 : 0, guildId]
+  );
+
+  return res.status(200).json({
+    message: `Guild is now ${isOpen ? 'open' : 'closed'} to join requests`,
+    isOpen,
+  });
+});
+
 module.exports = {
   generateGuildName,
   createGuild,
@@ -1076,4 +1137,5 @@ module.exports = {
   resolveEntry,
   getMyInvites,
   getGuildRequests,
+  updateGuildOpen,
 };

--- a/backend/controllers/guildController.js
+++ b/backend/controllers/guildController.js
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          guildController.js
+//  Description:   Controller functions for guild operations,
+//                 including name generation. 
+//                 Requires authentication.
+//
+//  Dependencies:  mysql2 connection pool (req.db)
+//                 errorHandler
+//                 guildNames
+//
+////////////////////////////////////////////////////////////////
+
+const { asyncHandler, AppError } = require('../middleware/errorHandler');
+const guildNames = require("../config/guildNames");
+
+/**
+ * @route   GET /api/guilds/name/generate
+ * @desc    Generate a unique guild name in the form "[adjective] [plural noun]"
+ *          Guaranteed to generate a name that isn't taken yet by a guild.
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 500                 - Adjectives or plural nouns list is empty
+ * @throws  {AppError} 503                 - All available guild names are in use, we need to add more!
+ * @returns {Promise<void>}                - Sends HTTP/JSON response with new guild name
+ */
+const generateGuildName = asyncHandler(async (req, res) => {
+  const { adjectives, pluralNouns } = guildNames;
+
+  // Verify there are names to choose from
+  if (!adjectives?.length || !pluralNouns?.length) 
+  {
+    throw new AppError(`Adjectives or plural nouns list is empty`, 500, 'Guild name word bank is currently unavailable.');
+  }
+
+  // Get all the names of every guild (we want to avoid these)
+  const [guildRows] = await req.db.query(
+    'SELECT NAME FROM Guild'
+  );
+
+  // Map rows to a set of taken names
+  const takenSet = new Set(guildRows.map(row => row.NAME));
+
+  // Put all available name combinations in an array
+  const availableNames = [];
+  for (const adj of adjectives)
+  {
+    for (const noun of pluralNouns)
+    {
+      const name = `${adj} ${noun}`;
+      if (!takenSet.has(name))
+      {
+        // This combination isn't used, so it's available
+        availableNames.push(name);
+      }
+    }
+  }
+
+  if (availableNames.length === 0) 
+  {
+    throw new AppError('All guild names are taken, add more!', 503, 'All guild names are currently in use, come back later for more!');
+  }
+
+  // Return a random name from the list
+  const name = availableNames[Math.floor(Math.random() * availableNames.length)];
+  return res.status(200).json({ name });
+});
+
+module.exports = { generateGuildName };

--- a/backend/controllers/leaderboardController.js
+++ b/backend/controllers/leaderboardController.js
@@ -18,27 +18,64 @@ const { asyncHandler } = require('../middleware/errorHandler');
 const PAGE_SIZE = 50;
 
 /**
+ * Helper function, fetches followed user IDs and queries paginated 
+ * leaderboard data for a given exp column.
+ * Returns an empty leaderboard if the requesting user follows nobody
+ * Called by getFollowedWeeklyLeaderboard() and getFollowedLifetimeLeaderboard()
+ *
+ * @param {import('express').Request} req - Express request object
+ * @param {string} expCol - Column to rank by ('WEEKLY_EXP' or 'LIFETIME_EXP')
+ * @returns {Promise<{ userRank, userExp, page, totalPages, leaderboard }>}
+ */
+const getFollowedLeaderboardData = async (req, expCol) => {
+  const [followed] = await req.db.query(
+    'SELECT FOLLOWING_ID FROM Follower WHERE FOLLOWER_ID = ?',
+    [req.user.id]
+  );
+  const followedIds = followed.map(f => f.FOLLOWING_ID);
+
+  // Return empty leaderboard if followedIds empty to avoid SQL error
+  if (followedIds.length === 0)
+  {
+    return { userRank: null, userExp: null, page: 1, totalPages: 0, leaderboard: [] };
+  }
+
+  const page = parseInt(req.query.page) || 1;
+  return getLeaderboard(req.db, req.user.id, expCol, page, followedIds);
+};
+
+/**
  * Helper function, queries paginated leaderboard data for a given exp column
+ * Generic but can be provided filtered IDs for follower leaderboard
  * Returns a page of all users ranked by exp
  * Returns requesting user's rank and exp regardless of page
  *
- * @param {Object} db     - Database connection pool
- * @param {number} userId - Requesting user's ID
- * @param {string} expCol - Column to rank by ('WEEKLY_EXP' or 'LIFETIME_EXP')
- * @param {number} page   - Page number to fetch (1-indexed)
- * @returns {Promise<{ userRank, userExp, total, page, totalPages, leaderboard }>}
+ * @param {Object}        db        - Database connection pool
+ * @param {number}        userId    - Requesting user's ID
+ * @param {string}        expCol    - Column to rank by ('WEEKLY_EXP' or 'LIFETIME_EXP')
+ * @param {number}        page      - Page number to fetch (1-indexed)
+ * @param {number[]|null} filterIds - If provided, only rank these user IDs. null = all users.
+ * @returns {Promise<{ userRank, userExp, page, totalPages, leaderboard }>}
  */
-const getLeaderboard = async (db, userId, expCol, page) =>
+const getLeaderboard = async (db, userId, expCol, page, filterIds = null) =>
 {
-  // Get total user count for pagination
-  const [[{ total }]] = await db.query('SELECT COUNT(*) AS total FROM User');
+  // Filter IDs based on given argument
+  const whereClause = filterIds ? `WHERE u.ID IN (${filterIds.map(() => '?').join(',')})` : '';
+  const filterParams = filterIds ?? [];
+
+  // Get total filtered user count for pagination
+  const [[{ total }]] = await db.query(
+    `SELECT COUNT(*) AS total FROM User u ${whereClause}`,
+    filterParams
+  );
+
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
   // Ensure page between 1 and totalPages
   const safePage = Math.min(Math.max(1, page), totalPages || 1);
   const offset   = (safePage - 1) * PAGE_SIZE;
 
-  // Rank users and paginate
+  // Rank filtered users and paginate
   // Include username, firstname, and profile picture for displaying
   const [rows] = await db.query(
     `SELECT * FROM (
@@ -56,10 +93,11 @@ const getLeaderboard = async (db, userId, expCol, page) =>
         JOIN StoreItem si ON si.ID = p.ITEM_ID
         WHERE p.IS_EQUIPPED = 1 AND si.TYPE = 'profile_picture'
       ) pfp ON pfp.USER_ID = u.ID
+      ${whereClause}
     ) ranked
     ORDER BY \`rank\` ASC, USERNAME ASC
     LIMIT ? OFFSET ?`,
-    [PAGE_SIZE, offset]
+    [...filterParams, PAGE_SIZE, offset]
   );
 
   // Find requesting user's rank and exp regardless of page
@@ -122,7 +160,39 @@ const getLifetimeLeaderboard = asyncHandler(async (req, res) =>
   return res.status(200).json(data);
 });
 
+/**
+ * @route   GET /api/leaderboard/followed/weekly
+ * @desc    Fetch paginated followed users leaderboard ranked by weekly exp
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>}                - Sends HTTP/JSON response with follower weekly leaderboard
+ */
+const getFollowedWeeklyLeaderboard = asyncHandler(async (req, res) =>
+{
+  const data = await getFollowedLeaderboardData(req, 'WEEKLY_EXP');
+  return res.status(200).json(data);
+});
+
+/**
+ * @route   GET /api/leaderboard/followed/lifetime
+ * @desc    Fetch paginated followed users leaderboard ranked by lifetime exp
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>}                - Sends HTTP/JSON response with lifetime leaderboard
+ */
+const getFollowedLifetimeLeaderboard = asyncHandler(async (req, res) =>
+{
+  const data = await getFollowedLeaderboardData(req, 'LIFETIME_EXP');
+  return res.status(200).json(data);
+});
+
 module.exports = {
   getWeeklyLeaderboard,
   getLifetimeLeaderboard,
+  getFollowedWeeklyLeaderboard,
+  getFollowedLifetimeLeaderboard,
 };

--- a/backend/controllers/leaderboardController.js
+++ b/backend/controllers/leaderboardController.js
@@ -9,13 +9,12 @@
 //
 //  Dependencies:  mysql2 connection pool (req.db)
 //                 errorHandler
+//                 paginationConfig
 //
 ////////////////////////////////////////////////////////////////
 
 const { asyncHandler } = require('../middleware/errorHandler');
-
-// Max number of users shown on a page of the leaderboard
-const PAGE_SIZE = 50;
+const { PAGE_SIZES } = require('../config/paginationConfig');
 
 /**
  * Helper function, fetches followed user IDs and queries paginated 
@@ -69,11 +68,11 @@ const getLeaderboard = async (db, userId, expCol, page, filterIds = null) =>
     filterParams
   );
 
-  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const totalPages = Math.ceil(total / PAGE_SIZES.LEADERBOARD);
 
   // Ensure page between 1 and totalPages
   const safePage = Math.min(Math.max(1, page), totalPages || 1);
-  const offset   = (safePage - 1) * PAGE_SIZE;
+  const offset   = (safePage - 1) * PAGE_SIZES.LEADERBOARD;
 
   // Rank filtered users and paginate
   // Include username, firstname, and profile picture for displaying
@@ -97,7 +96,7 @@ const getLeaderboard = async (db, userId, expCol, page, filterIds = null) =>
     ) ranked
     ORDER BY \`rank\` ASC, USERNAME ASC
     LIMIT ? OFFSET ?`,
-    [...filterParams, PAGE_SIZE, offset]
+    [...filterParams, PAGE_SIZES.LEADERBOARD, offset]
   );
 
   // Find requesting user's rank and exp regardless of page

--- a/backend/controllers/leaderboardController.js
+++ b/backend/controllers/leaderboardController.js
@@ -130,8 +130,12 @@ const getFollowedLeaderboardData = async (req, expCol) => {
     return { userRank: null, userExp: null, page: 1, totalPages: 0, leaderboard: [] };
   }
 
+  // Include the requesting user in the ranked pool so their rank
+  // is considered relative to their followed users, not globally
+  const poolIds = [...new Set([...followedIds, req.user.id])];
+
   const page = parseInt(req.query.page) || 1;
-  return getLeaderboard(req.db, req.user.id, expCol, page, followedIds);
+  return getLeaderboard(req.db, req.user.id, expCol, page, poolIds);
 };
 
 /**
@@ -151,6 +155,7 @@ const getLeaderboard = async (db, userId, expCol, page, filterIds = null) =>
 {
   // Filter IDs based on given argument
   const whereClause = filterIds ? `WHERE u.ID IN (${filterIds.map(() => '?').join(',')})` : '';
+  const rankWhereClause  = filterIds ? `WHERE ID IN (${filterIds.map(() => '?').join(',')})` : '';
   const filterParams = filterIds ?? [];
 
   // Get total filtered user count for pagination
@@ -199,9 +204,10 @@ const getLeaderboard = async (db, userId, expCol, page, filterIds = null) =>
         DENSE_RANK() OVER (ORDER BY ${expCol} DESC) AS \`rank\`,
         ${expCol} AS exp
       FROM User
+      ${rankWhereClause}
     ) ranked
     WHERE ID = ?`,
-    [userId]
+    [...(filterIds ?? []), userId]
   );
 
   return {

--- a/backend/controllers/leaderboardController.js
+++ b/backend/controllers/leaderboardController.js
@@ -17,6 +17,97 @@ const { asyncHandler } = require('../middleware/errorHandler');
 const { PAGE_SIZES } = require('../config/paginationConfig');
 
 /**
+ * Helper function, queries paginated guild leaderboard data for a given exp column
+ * Returns a page of guilds ranked by exp
+ * Returns the requesting user's guild rank and exp regardless of page,
+ * or null if the user is not in a guild.
+ *
+ * @param {Object} db     - Database connection pool
+ * @param {number} userId - Requesting user's ID
+ * @param {string} expCol - Column to rank by ('WEEKLY_EXP' or 'LIFETIME_EXP')
+ * @param {number} page   - Page number to fetch (1-indexed)
+ * @returns {Promise<{ guildRank, guildExp, guildId, page, totalPages, leaderboard }>}
+ */
+const getGuildLeaderboardData = async (db, userId, expCol, page) =>
+{
+  // Get total guild count for pagination
+  const [[{ total }]] = await db.query(
+    'SELECT COUNT(*) AS total FROM Guild'
+  );
+
+  const totalPages = Math.ceil(total / PAGE_SIZES.LEADERBOARD_GUILD);
+  const safePage   = Math.min(Math.max(1, page), totalPages || 1);
+  const offset     = (safePage - 1) * PAGE_SIZES.LEADERBOARD_GUILD;
+
+  // Rank guilds and paginate
+  // Include guild picture for displaying (mirrors profile picture join for users)
+  const [rows] = await db.query(
+    `SELECT * FROM (
+      SELECT
+        g.ID,
+        DENSE_RANK() OVER (ORDER BY g.${expCol} DESC) AS \`rank\`,
+        g.NAME,
+        g.${expCol} AS exp,
+        gi.itemName AS guildPicture
+      FROM Guild g
+      LEFT JOIN (
+        SELECT gu.GUILD_ID, si.NAME AS itemName
+        FROM GuildUnlock gu
+        JOIN StoreItem si ON si.ID = gu.ITEM_ID
+        WHERE gu.IS_EQUIPPED = 1 AND si.TYPE = 'profile_picture' AND si.IS_GUILD_ITEM = 1
+      ) gi ON gi.GUILD_ID = g.ID
+    ) ranked
+    ORDER BY \`rank\` ASC, NAME ASC
+    LIMIT ? OFFSET ?`,
+    [PAGE_SIZES.LEADERBOARD_GUILD, offset]
+  );
+
+  // Find requesting user's guild rank and exp regardless of page
+  // Returns null fields if user is not in a guild
+  const [[membership]] = await db.query(
+    'SELECT GUILD_ID FROM GuildMember WHERE USER_ID = ?',
+    [userId]
+  );
+
+  let guildRank = null;
+  let guildExp  = null;
+  let guildId   = null;
+
+  if (membership)
+  {
+    guildId = membership.GUILD_ID;
+    const [[guildRankRow]] = await db.query(
+      `SELECT \`rank\`, exp FROM (
+        SELECT
+          ID,
+          DENSE_RANK() OVER (ORDER BY ${expCol} DESC) AS \`rank\`,
+          ${expCol} AS exp
+        FROM Guild
+      ) ranked
+      WHERE ID = ?`,
+      [guildId]
+    );
+    guildRank = guildRankRow?.rank ?? null;
+    guildExp  = guildRankRow?.exp  ?? null;
+  }
+
+  return {
+    guildRank,
+    guildExp,
+    guildId,
+    page:      safePage,
+    totalPages,
+    leaderboard: rows.map(row => ({
+      rank:         row.rank,
+      id:           row.ID,
+      name:         row.NAME,
+      exp:          row.exp,
+      guildPicture: row.guildPicture ?? null,
+    }))
+  };
+};
+
+/**
  * Helper function, fetches followed user IDs and queries paginated 
  * leaderboard data for a given exp column.
  * Returns an empty leaderboard if the requesting user follows nobody
@@ -84,13 +175,14 @@ const getLeaderboard = async (db, userId, expCol, page, filterIds = null) =>
         u.USERNAME,
         u.FIRSTNAME,
         u.${expCol} AS exp,
-        pfp.NAME AS profilePicture
+        pfp.itemName AS profilePicture
       FROM User u
       LEFT JOIN (
-        SELECT p.USER_ID, si.NAME
+        SELECT p.USER_ID, si.NAME as itemName
         FROM Purchase p
         JOIN StoreItem si ON si.ID = p.ITEM_ID
         WHERE p.IS_EQUIPPED = 1 AND si.TYPE = 'profile_picture'
+          AND si.IS_GUILD_ITEM = 0
       ) pfp ON pfp.USER_ID = u.ID
       ${whereClause}
     ) ranked
@@ -189,9 +281,43 @@ const getFollowedLifetimeLeaderboard = asyncHandler(async (req, res) =>
   return res.status(200).json(data);
 });
 
+/**
+ * @route   GET /api/leaderboard/guilds/weekly
+ * @desc    Fetch paginated guild leaderboard ranked by weekly exp
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>}                - Sends HTTP/JSON response with weekly guild leaderboard
+ */
+const getGuildWeeklyLeaderboard = asyncHandler(async (req, res) =>
+{
+  const page = parseInt(req.query.page) || 1;
+  const data = await getGuildLeaderboardData(req.db, req.user.id, 'WEEKLY_EXP', page);
+  return res.status(200).json(data);
+});
+
+/**
+ * @route   GET /api/leaderboard/guilds/lifetime
+ * @desc    Fetch paginated guild leaderboard ranked by lifetime exp
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>}                - Sends HTTP/JSON response with lifetime guild leaderboard
+ */
+const getGuildLifetimeLeaderboard = asyncHandler(async (req, res) =>
+{
+  const page = parseInt(req.query.page) || 1;
+  const data = await getGuildLeaderboardData(req.db, req.user.id, 'LIFETIME_EXP', page);
+  return res.status(200).json(data);
+});
+
 module.exports = {
   getWeeklyLeaderboard,
   getLifetimeLeaderboard,
   getFollowedWeeklyLeaderboard,
   getFollowedLifetimeLeaderboard,
+  getGuildWeeklyLeaderboard,
+  getGuildLifetimeLeaderboard,
 };

--- a/backend/controllers/statsController.js
+++ b/backend/controllers/statsController.js
@@ -1,0 +1,172 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          statsController.js
+//  Description:   Controller functions for aggregate analytics
+//                 endpoints. Only includes opted-in users.
+//
+//  Dependencies:  mysql2 connection pool (req.db)
+//                 errorHandler
+//                 analyticsModel
+//
+////////////////////////////////////////////////////////////////
+
+const { asyncHandler, AppError } = require('../middleware/errorHandler');
+const { computeMedian } = require('../utils/analyticsModel');
+
+/**
+ * Helper function, computes median accuracy and median elapsed time
+ * for a given set of responses
+ *
+ * @param {Array} responses - Rows from Response JOIN User query
+ * @returns {{ medianAccuracy: number|null, medianElapsedTime: number|null }}
+ */
+const computeAggregateStats = (responses) => {
+  const accuracies   = responses.map(r => r.POINTS_POSSIBLE > 0
+    ? r.POINTS_EARNED / r.POINTS_POSSIBLE
+    : 0
+  );
+  const elapsedTimes = responses
+    .filter(r => r.ELAPSED_TIME != null)
+    .map(r => r.ELAPSED_TIME);
+
+  return {
+    medianAccuracy:    computeMedian(accuracies),
+    medianElapsedTime: computeMedian(elapsedTimes),
+  };
+};
+
+/**
+ * Helper function, groups responses by subcategory and
+ * computes aggregate stats per subcategory
+ *
+ * @param {Array} responses - Rows from Response JOIN User JOIN Question query
+ * @returns {Object} Map of subcategory -> { medianAccuracy, medianElapsedTime, responseCount }
+ */
+const computeSubcategoryBreakdown = (responses) => {
+  const bySubcategory = {};
+  for (const row of responses)
+  {
+    const sub = row.SUBCATEGORY ?? 'Unknown';
+    if (!bySubcategory[sub]) bySubcategory[sub] = [];
+    bySubcategory[sub].push(row);
+  }
+
+  const breakdown = {};
+  for (const [sub, rows] of Object.entries(bySubcategory))
+  {
+    const { medianAccuracy, medianElapsedTime } = computeAggregateStats(rows);
+    breakdown[sub] = {
+      medianAccuracy,
+      medianElapsedTime,
+      responseCount: rows.length,
+    };
+  }
+
+  return breakdown;
+};
+
+/**
+ * @route   GET /api/stats/aggregate
+ * @desc    Aggregate median accuracy and elapsed time across all opted-in users
+ *          Also returns a per-subcategory breakdown
+ * @access  Professor, Admin
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>}                - Sends HTTP/JSON response with aggregate stats
+ */
+const getAggregateStats = asyncHandler(async (req, res) => {
+  const [responses] = await req.db.query(
+    `SELECT r.POINTS_EARNED, r.POINTS_POSSIBLE, r.ELAPSED_TIME, q.SUBCATEGORY
+     FROM Response r
+     JOIN User u     ON u.ID = r.USERID
+     JOIN Question q ON q.ID = r.PROBLEM_ID
+     WHERE u.IS_SHARING_STATS = 1`
+  );
+
+  if (responses.length === 0)
+  {
+    return res.status(200).json({
+      medianAccuracy:       null,
+      medianElapsedTime:    null,
+      responseCount:        0,
+      subcategoryBreakdown: {},
+    });
+  }
+
+  const { medianAccuracy, medianElapsedTime } = computeAggregateStats(responses);
+  const subcategoryBreakdown = computeSubcategoryBreakdown(responses);
+
+  return res.status(200).json({
+    medianAccuracy,
+    medianElapsedTime,
+    responseCount: responses.length,
+    subcategoryBreakdown,
+  });
+});
+
+/**
+ * @route   GET /api/stats/aggregate/:questionId
+ * @desc    Aggregate median accuracy and elapsed time for a single question
+ *          across all opted-in users
+ * @access  Professor, Admin
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - If questionId is not a valid ID
+ * @throws  {AppError} 404                 - If question does not exist
+ * @returns {Promise<void>}                - Sends HTTP/JSON response with per-question stats
+ */
+const getAggregateStatsByQuestion = asyncHandler(async (req, res) => {
+  const context    = 'getAggregateStatsByQuestion';
+  const questionId = parseInt(req.params.questionId);
+
+  if (isNaN(questionId) || questionId <= 0)
+  {
+    throw new AppError(`[${context}] Invalid question ID: ${req.params.questionId}`, 400, 'Invalid question ID');
+  }
+
+  const [[question]] = await req.db.query(
+    'SELECT ID FROM Question WHERE ID = ?',
+    [questionId]
+  );
+  if (!question)
+  {
+    throw new AppError(`[${context}] Question not found: ${questionId}`, 404, 'Question not found');
+  }
+
+  const [responses] = await req.db.query(
+    `SELECT r.POINTS_EARNED, r.POINTS_POSSIBLE, r.ELAPSED_TIME
+     FROM Response r
+     JOIN User u ON u.ID = r.USERID
+     WHERE r.PROBLEM_ID = ? AND u.IS_SHARING_STATS = 1`,
+    [questionId]
+  );
+
+  if (responses.length === 0)
+  {
+    return res.status(200).json({
+      questionId,
+      medianAccuracy:    null,
+      medianElapsedTime: null,
+      responseCount:     0,
+    });
+  }
+
+  const { medianAccuracy, medianElapsedTime } = computeAggregateStats(responses);
+
+  return res.status(200).json({
+    questionId,
+    medianAccuracy,
+    medianElapsedTime,
+    responseCount: responses.length,
+  });
+});
+
+module.exports = {
+  getAggregateStats,
+  getAggregateStatsByQuestion,
+};

--- a/backend/controllers/statsController.js
+++ b/backend/controllers/statsController.js
@@ -10,11 +10,13 @@
 //  Dependencies:  mysql2 connection pool (req.db)
 //                 errorHandler
 //                 analyticsModel
+//                 validationUtils
 //
 ////////////////////////////////////////////////////////////////
 
 const { asyncHandler, AppError } = require('../middleware/errorHandler');
 const { computeMedian } = require('../utils/analyticsModel');
+const { normalizeDBString } = require('../utils/validationUtils');
 
 /**
  * Helper function, computes median accuracy and median elapsed time
@@ -49,7 +51,7 @@ const computeSubcategoryBreakdown = (responses) => {
   const bySubcategory = {};
   for (const row of responses)
   {
-    const sub = row.SUBCATEGORY ?? 'Unknown';
+    const sub = normalizeDBString(row.SUBCATEGORY ?? 'Unknown');
     if (!bySubcategory[sub]) bySubcategory[sub] = [];
     bySubcategory[sub].push(row);
   }

--- a/backend/controllers/storeController.js
+++ b/backend/controllers/storeController.js
@@ -28,7 +28,7 @@ const { parseUserId }            = require('../utils/validationUtils');
  */
 const getStoreItems = asyncHandler(async (req, res) => {
   const [items] = await req.db.query(
-    'SELECT ID, TYPE, COST, NAME FROM StoreItem'
+    'SELECT ID, TYPE, COST, NAME, IS_GUILD_ITEM FROM StoreItem'
   );
 
   return res.status(200).json({ items });
@@ -53,7 +53,7 @@ const purchaseItem = asyncHandler(async (req, res) => {
 
   // Fetch item
   const [items] = await req.db.query(
-    'SELECT ID, TYPE, COST, NAME FROM StoreItem WHERE ID = ?',
+    'SELECT ID, TYPE, COST, NAME, IS_GUILD_ITEM FROM StoreItem WHERE ID = ?',
     [itemId]
   );
   if (items.length === 0)
@@ -61,6 +61,12 @@ const purchaseItem = asyncHandler(async (req, res) => {
     throw new AppError(`[${context}] Store item not found: ${itemId}`, 404, 'Item not found');
   }
   const item = items[0];
+
+  // Can't purchase guild items, just unlock when guild coin bank reaches threshold
+  if (item.IS_GUILD_ITEM)
+  {
+    throw new AppError(`[${context}] Item ${itemId} is a guild item and cannot be purchased directly`, 400, 'Guild items cannot be purchased directly');
+  }
 
   // Check if already purchased
   const [existing] = await req.db.query(

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -514,6 +514,53 @@ const searchUsers = asyncHandler(async (req, res) => {
   });
 });
 
+/**
+ * @route   PUT /api/users/:id/stats-opt-in
+ * @desc    Toggle IS_SHARING_STATS for the user
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req  - Express request object
+ * @param {import('express').Response} res  - Express response object
+ * @throws  {AppError} 400                  - Throwable by parseUserId
+ * @throws  {AppError} 403                  - Throwable by assertUserOwnership
+ * @throws  {AppError} 404                  - If user not found
+ * @returns {Promise<void>}                 - Sends HTTP/JSON with new opt-in state
+ */
+const updateStatsOptIn = asyncHandler(async (req, res) => {
+  const context = 'updateStatsOptIn';
+  const userId  = parseUserId(req.params.id, context);
+
+  // Ensure user is toggling for themselves
+  assertUserOwnership(req.user, userId, context);
+
+  const { optIn } = req.body;
+  if (typeof optIn !== 'boolean')
+  {
+    throw new AppError(`[${context}] Invalid optIn value: ${optIn}`, 400, 'optIn must be a boolean');
+  }
+
+  // Get user
+  const [users] = await req.db.query(
+    'SELECT ID FROM User WHERE ID = ?',
+    [userId]
+  );
+  if (users.length === 0)
+  {
+    throw new AppError(`[${context}] User not found: ${userId}`, 404, 'User not found');
+  }
+
+  // Set opt-in status
+  await req.db.query(
+    'UPDATE User SET IS_SHARING_STATS = ? WHERE ID = ?',
+    [optIn ? 1 : 0, userId]
+  );
+
+  return res.status(200).json({
+    message: `Stats sharing ${optIn ? 'enabled' : 'disabled'}`,
+    optIn,
+  });
+});
+
 module.exports = {
   deleteAccount,
   getUserInfo,
@@ -524,4 +571,5 @@ module.exports = {
   followUser,
   unfollowUser,
   searchUsers,
+  updateStatsOptIn,
 };

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -22,6 +22,39 @@ const { parseUserId, validateName } = require('../utils/validationUtils');
 const { EQUIP_LIMITS } = require('../../shared/itemConfig');
 
 /**
+ * Helper function, ensures followee exists 
+ * and checks if follower is following followee
+ * Used in followUser and unfollowUser
+ * 
+ * @param   {Object} db         - Database connection pool
+ * @param   {Object} followerId - The ID of the follower user
+ * @param   {number} followeeId - The ID of the followee user
+ * @param   {string} context    - Caller name for error logging (e.g. 'followUser')
+ * @throws  {AppError} 404      - If followee ID not found
+ * @returns {Promise<boolean>}  - True if follower is currently following followee, else false
+ */
+const isFollowing = async (db, followerId, followeeId, context) => {
+  // Ensure the user we want to (un)follow exists
+  const [users] = await db.query(
+    'SELECT ID FROM User WHERE ID = ?',
+    [followeeId]
+  );
+  if (users.length === 0)
+  {
+    throw new AppError(`[${context}] Failed to check follow relationship, followee ID not found: ${followeeId}`, 404, 'User not found');
+  }
+
+  // Check if a Follower row exists for the follower-followee relationship
+  const [follows] = await db.query(
+    'SELECT FOLLOWER_ID FROM Follower WHERE FOLLOWER_ID = ? AND FOLLOWING_ID = ?',
+    [followerId, followeeId]
+  );
+
+  // True if follow relationship found, else false
+  return (follows.length !== 0 ? true : false);
+};
+
+/**
  * Helper function, asserts that requesting user matches target user ID
  * Ensures that users can't initiate operations on other users
  * 
@@ -359,6 +392,80 @@ const unequipItem = asyncHandler(async (req, res) => {
   return res.status(200).json({ message: `Item unequipped successfully` });
 });
 
+/**
+ * @route   POST /api/users/:id/follow
+ * @desc    Follow the user with the given ID
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req  - Express request object
+ * @param {import('express').Response} res  - Express response object
+ * @throws  {AppError} 400                  - If followee is already followed, user is trying to follow themselves, or throwable by parseUserId
+ * @throws  {AppError} 404                  - Throwable by isFollowing
+ * @returns {Promise<void>}                 - Sends HTTP/JSON response confirming follow
+ */
+const followUser = asyncHandler(async (req, res) => {
+  const context    = 'followUser';
+  const followerId = req.user.id;
+  const followeeId = parseUserId(req.params.id, context);
+
+  // Ensure user is not trying to follow themselves
+  if (followerId === followeeId)
+  {
+    throw new AppError(`User ${followerId} cannot follow themselves`, 400, 'User cannot follow themselves.');
+  }
+
+  // Ensure proposed followee exists and that we _don't_ already follow them
+  const alreadyFollowing = await isFollowing(req.db, followerId, followeeId, context);
+  if (alreadyFollowing)
+  {
+    throw new AppError(`User ${followerId} is already following ${followeeId}`, 400, 'User is already followed.');
+  }
+
+  // Insert Follower row, creating follower relationship
+  // NOTE: This is a one-way relationship, this doesn't
+  //       mean that followee follows follower.
+  await req.db.query(
+    'INSERT INTO Follower (FOLLOWER_ID, FOLLOWING_ID) VALUES (?, ?)',
+    [followerId, followeeId]
+  );
+
+  return res.status(200).json({ message: 'User followed successfully' });
+});
+
+/**
+ * @route   DELETE /api/users/:id/follow
+ * @desc    Unfollow the user with the given ID
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req  - Express request object
+ * @param {import('express').Response} res  - Express response object
+ * @throws  {AppError} 400                  - Follower is not already following followee, throwable by parseUserId
+ * @throws  {AppError} 404                  - Throwable by isFollowing
+ * @returns {Promise<void>}                 - Sends HTTP/JSON response confirming unfollow
+ */
+const unfollowUser = asyncHandler(async (req, res) => {
+  const context = 'unfollowUser';
+  const followerId = req.user.id;
+  const followeeId = parseUserId(req.params.id, context);
+  
+  // Ensure proposed followee exists and that we already follow them
+  const alreadyFollowing = await isFollowing(req.db, followerId, followeeId, context);
+  if (!alreadyFollowing)
+  {
+    throw new AppError(`User ${followerId} is not following ${followeeId}`, 400, 'User is not followed.');
+  }
+  
+  // Delete Follower row, eliminating follower relationship
+  // NOTE: This is a one-way relationship, this doesn't
+  //       mean that followee no longer follows follower
+  await req.db.query(
+    'DELETE FROM Follower WHERE FOLLOWER_ID = ? AND FOLLOWING_ID = ?',
+    [followerId, followeeId]
+  );
+
+  return res.status(200).json({ message: 'User unfollowed successfully' });
+});
+
 module.exports = {
   deleteAccount,
   getUserInfo,
@@ -366,4 +473,6 @@ module.exports = {
   getPurchases,
   equipItem,
   unequipItem,
+  followUser,
+  unfollowUser,
 };

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -13,6 +13,7 @@
 //                errorHandler
 //                validationUtils
 //                itemConfig
+//                paginationConfig
 //
 ////////////////////////////////////////////////////////////////
 
@@ -20,6 +21,7 @@ const { notifyUserEvent } = require('../services/discordWebhook');
 const { asyncHandler, AppError } = require('../middleware/errorHandler');
 const { parseUserId, validateName } = require('../utils/validationUtils');
 const { EQUIP_LIMITS } = require('../../shared/itemConfig');
+const { PAGE_SIZES } = require('../config/paginationConfig');
 
 /**
  * Helper function, ensures followee exists 
@@ -466,6 +468,52 @@ const unfollowUser = asyncHandler(async (req, res) => {
   return res.status(200).json({ message: 'User unfollowed successfully' });
 });
 
+/**
+ * @route   GET /api/users/search
+ * @desc    Search users by username (partial, case-insensitive), paginated
+ *          Call with username and page as query parameters
+ * @access  Protected
+ *
+ * @param {import('express').Request}  req  - Express request object
+ * @param {import('express').Response} res  - Express response object
+ * @returns {Promise<void>}                 - Sends HTTP/JSON response with paginated user results
+ */
+const searchUsers = asyncHandler(async (req, res) => {
+  const username = req.query.username ?? '';
+  const page     = parseInt(req.query.page) || 1;
+
+  // Get total user count for pagination metadata
+  const [[{ totalUsers }]] = await req.db.query(
+    'SELECT COUNT(*) AS totalUsers FROM User WHERE USERNAME LIKE ?',
+    [`%${username}%`]
+  );
+
+  // Pagination
+  const totalPages = Math.ceil(totalUsers / PAGE_SIZES.USER_SEARCH);
+  const safePage   = Math.min(Math.max(1, page), totalPages || 1);
+  const offset     = (safePage - 1) * PAGE_SIZES.USER_SEARCH;
+
+  // Use LIKE with % for partial, case-insensitive match
+  const [users] = await req.db.query(
+    `SELECT ID, USERNAME, FIRSTNAME, LASTNAME
+     FROM User
+     WHERE USERNAME LIKE ?
+     ORDER BY USERNAME ASC
+     LIMIT ? OFFSET ?`,
+    [`%${username}%`, PAGE_SIZES.USER_SEARCH, offset]
+  );
+
+  return res.status(200).json({
+    users,
+    pagination: {
+      page: safePage,
+      pageSize: PAGE_SIZES.USER_SEARCH,
+      totalUsers,
+      totalPages,
+    }
+  });
+});
+
 module.exports = {
   deleteAccount,
   getUserInfo,
@@ -475,4 +523,5 @@ module.exports = {
   unequipItem,
   followUser,
   unfollowUser,
+  searchUsers,
 };

--- a/backend/jobs/expReset.js
+++ b/backend/jobs/expReset.js
@@ -19,12 +19,14 @@ const startExpResetJobs = () =>
   // Every day at midnight UTC
   cron.schedule('0 0 * * *', async () => {
   await pool.query('UPDATE User SET DAILY_EXP = 0');
+  await pool.query('UPDATE Guild SET DAILY_EXP = 0');
   console.log('Daily EXP reset');
   });
 
   // Every Monday at midnight UTC
   cron.schedule('0 0 * * 1', async () => {
   await pool.query('UPDATE User SET WEEKLY_EXP = 0');
+  await pool.query('UPDATE Guild SET WEEKLY_EXP = 0');
   console.log('Weekly EXP reset');
   });
 };

--- a/backend/middleware/adminOrProf.js
+++ b/backend/middleware/adminOrProf.js
@@ -1,0 +1,35 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          adminOrProf.js
+//  Description:   Express middleware for endpoints accessible
+//                 to both professors and admins.
+//
+//  Dependencies:  adminMiddleware
+//                 authMiddleware
+//                 requireRole
+//
+////////////////////////////////////////////////////////////////
+
+const adminMiddleware = require('./adminMiddleware');
+const authMiddleware  = require('./authMiddleware');
+const requireRole     = require('./requireRole');
+
+/**
+ * Middleware chain for endpoints shared between admins and professors.
+ * Routes admin requests (with ADMIN_KEY) through adminMiddleware,
+ * professor/user requests through authMiddleware + requireRole.
+ */
+const adminOrProf = [
+  (req, res, next) => {
+    const token = req.headers.authorization?.split(' ')[1]?.trim();
+    token === process.env.ADMIN_KEY
+      ? adminMiddleware(req, res, next)
+      : authMiddleware(req, res, next);
+  },
+  requireRole('admin', 'professor')
+];
+
+module.exports = adminOrProf;

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -689,7 +689,7 @@ router.post('/problems/:id/publish', adminOrProf, asyncHandler(async (req, res) 
  * @returns {Promise<void>} - JSON response confirming store item created
  */
 router.post('/store/createitem', adminMiddleware, asyncHandler(async (req, res) => {
-  const { itemType, itemCost, itemName } = req.body;
+  const { itemType, itemCost, itemName, isGuildItem } = req.body;
 
   if (itemType == null || itemCost == null || itemName == null)
   {
@@ -710,15 +710,50 @@ router.post('/store/createitem', adminMiddleware, asyncHandler(async (req, res) 
 
   // Insert new item into db
   const [result] = await req.db.query(
-    'INSERT INTO StoreItem (TYPE, COST, NAME) VALUES (?, ?, ?)',
-    [itemType, itemCost, itemName]
+    'INSERT INTO StoreItem (TYPE, COST, NAME, IS_GUILD_ITEM) VALUES (?, ?, ?, ?)',
+    [itemType, itemCost, itemName, isGuildItem ? 1 : 0]
   );
   const itemId = result.insertId;
 
   // Send Discord notification
-  notifyUserEvent(`Item ${itemId} created: ${itemName} (${itemType}), costs ${itemCost} coins`);
+  notifyUserEvent(`Item ${itemId} created: ${itemName} (${itemType}), costs ${itemCost} coins, guild item: ${isGuildItem ? 'yes' : 'no'}`);
 
   res.status(201).json({ message: "Store item successfully created", itemId});
+}));
+
+/**
+ * @route   DELETE /api/admin/store/items/:id
+ * @desc    Delete a store item by ID
+ * @access  Admin
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - If item ID is invalid
+ * @throws  {AppError} 404                 - If item not found
+ * @returns {Promise<void>}                - Sends HTTP/JSON confirming deletion
+ */
+router.delete('/store/items/:id', adminMiddleware, asyncHandler(async (req, res) => {
+  const itemId = parseInt(req.params.id);
+
+  if (isNaN(itemId) || itemId <= 0)
+  {
+    throw new AppError(`Invalid item ID: ${req.params.id}`, 400, 'Invalid item ID');
+  }
+
+  const [[item]] = await req.db.query(
+    'SELECT ID, NAME FROM StoreItem WHERE ID = ?',
+    [itemId]
+  );
+  if (!item)
+  {
+    throw new AppError(`Item not found: ${itemId}`, 404, 'Item not found');
+  }
+
+  await req.db.query('DELETE FROM StoreItem WHERE ID = ?', [itemId]);
+
+  notifyUserEvent(`Store item deleted: ${item.NAME} (ID ${itemId})`);
+
+  return res.status(200).json({ message: 'Store item deleted successfully' });
 }));
 
 module.exports = router;

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -30,6 +30,7 @@ const router = express.Router();
 const { asyncHandler, AppError } = require('../middleware/errorHandler');
 const adminMiddleware = require("../middleware/adminMiddleware");
 const authMiddleware = require('../middleware/authMiddleware');
+const adminOrProf = require('../middleware/adminOrProf');
 const requireRole = require('../middleware/requireRole');
 const { notifyUserEvent } = require("../services/discordWebhook");
 const { ITEM_TYPES } = require('../../shared/itemConfig');
@@ -40,23 +41,6 @@ const mailjet = Mailjet.apiConnect(
   process.env.MJ_APIKEY_PUBLIC,
   process.env.MJ_APIKEY_PRIVATE
 );
-
-/**
- * Helper middleware for endpoints shared between admins and professors
- * Routes admin requests (requests with ADMIN_KEY) through adminMiddleware
- * Routes professor requests (requests without ADMIN_KEY) through authMiddleware
- * Enforces role to ensure only admins and professors get intended access
- * @type {import('express').RequestHandler[]}
- */
-const adminOrProf = [
-  (req, res, next) => {
-    const token = req.headers.authorization?.split(" ")[1]?.trim();
-    token === process.env.ADMIN_KEY
-      ? adminMiddleware(req, res, next)
-      : authMiddleware(req, res, next);
-  },
-  requireRole('admin', 'professor')
-];
 
 /**
  * Helper function, gets questions for a given draft/published state

--- a/backend/routes/guilds.js
+++ b/backend/routes/guilds.js
@@ -13,11 +13,26 @@
 //
 ////////////////////////////////////////////////////////////////
 
-const express = require("express");
-const router = express.Router();
+const express    = require('express');
+const router     = express.Router();
+const authMiddleware = require('../middleware/authMiddleware');
 
-const authMiddleware = require("../middleware/authMiddleware");
-const { generateGuildName } = require("../controllers/guildController");
+const {
+  generateGuildName,
+  createGuild,
+  leaveGuild,
+  deleteGuild,
+  getGuildInfo,
+  contributeCoins,
+  kickMember,
+  updateMemberRole,
+  equipGuildItem,
+  unequipGuildItem,
+  inviteUser,
+  requestToJoin,
+  resolveEntry,
+  getGuildRequests,
+} = require('../controllers/guildController');
 
 /**
  * @route   GET /api/guilds/name/generate
@@ -25,6 +40,103 @@ const { generateGuildName } = require("../controllers/guildController");
  *          Guaranteed to generate a name that isn't taken yet by a guild.
  * @access  Protected
  */
-router.get("/name/generate", authMiddleware, generateGuildName);
+router.get('/name/generate', authMiddleware, generateGuildName);
+
+/**
+ * @route   POST /api/guilds
+ * @desc    Create a new guild
+ * @access  Protected
+ */
+router.post('/', authMiddleware, createGuild);
+
+//////////////////////////////////////////////////////////////////////////////////////
+//
+//   ##### ALL NON-WILDCARD ROUTES MUST GO BEFORE THESE WILDCARD (/:id) ROUTES #####
+//
+//////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @route   GET /api/guilds/:id
+ * @desc    Get guild info and equipped items
+ * @access  Protected
+ */
+router.get('/:id', authMiddleware, getGuildInfo);
+
+/**
+ * @route   DELETE /api/guilds/:id/leave
+ * @desc    Leave a guild (Member or Officer only)
+ * @access  Protected
+ */
+router.delete('/:id/leave', authMiddleware, leaveGuild);
+
+/**
+ * @route   DELETE /api/guilds/:id
+ * @desc    Delete a guild (Owner only)
+ * @access  Protected
+ */
+router.delete('/:id', authMiddleware, deleteGuild);
+
+/**
+ * @route   POST /api/guilds/:id/contribute
+ * @desc    Contribute coins to guild bank
+ * @access  Protected
+ */
+router.post('/:id/contribute', authMiddleware, contributeCoins);
+
+/**
+ * @route   DELETE /api/guilds/:id/members/:userId
+ * @desc    Kick a member from the guild
+ * @access  Protected
+ */
+router.delete('/:id/members/:userId', authMiddleware, kickMember);
+
+/**
+ * @route   PATCH /api/guilds/:id/members/:userId/role
+ * @desc    Promote or demote a guild member
+ * @access  Protected
+ */
+router.patch('/:id/members/:userId/role', authMiddleware, updateMemberRole);
+
+/**
+ * @route   PUT /api/guilds/:id/equip
+ * @desc    Equip an unlocked guild item
+ * @access  Protected
+ */
+router.put('/:id/equip', authMiddleware, equipGuildItem);
+
+/**
+ * @route   PUT /api/guilds/:id/unequip
+ * @desc    Unequip an equipped guild item
+ * @access  Protected
+ */
+router.put('/:id/unequip', authMiddleware, unequipGuildItem);
+
+/**
+ * @route   POST /api/guilds/:id/invite
+ * @desc    Invite a user to the guild
+ * @access  Protected
+ */
+router.post('/:id/invite', authMiddleware, inviteUser);
+
+/**
+ * @route   POST /api/guilds/:id/request
+ * @desc    Request to join a guild
+ * @access  Protected
+ */
+router.post('/:id/request', authMiddleware, requestToJoin);
+
+/**
+ * @route   PATCH /api/guilds/:id/entry/:userId
+ * @desc    Accept or reject a guild entry
+ * @access  Protected
+ */
+router.patch('/:id/entry/:userId', authMiddleware, resolveEntry);
+
+/**
+ * @route   GET /api/guilds/:id/requests
+ * @desc    Get pending join requests for a guild
+ * @access  Protected
+ */
+router.get('/:id/requests', authMiddleware, getGuildRequests);
 
 module.exports = router;

--- a/backend/routes/guilds.js
+++ b/backend/routes/guilds.js
@@ -32,6 +32,7 @@ const {
   requestToJoin,
   resolveEntry,
   getGuildRequests,
+  updateGuildOpen
 } = require('../controllers/guildController');
 
 /**
@@ -138,5 +139,12 @@ router.patch('/:id/entry/:userId', authMiddleware, resolveEntry);
  * @access  Protected
  */
 router.get('/:id/requests', authMiddleware, getGuildRequests);
+
+/**
+ * @route   PATCH /api/guilds/:id/open
+ * @desc    Toggle guild open/closed status for join requests
+ * @access  Protected — Officer or Owner only
+ */
+router.patch('/:id/open', authMiddleware, updateGuildOpen);
 
 module.exports = router;

--- a/backend/routes/guilds.js
+++ b/backend/routes/guilds.js
@@ -1,0 +1,30 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          guilds.js
+//  Description:   Express routes for guild operations.
+//                 Protected by JWT authentication.
+//
+//  Dependencies:  express
+//                 authMiddleware
+//                 guildController
+//
+////////////////////////////////////////////////////////////////
+
+const express = require("express");
+const router = express.Router();
+
+const authMiddleware = require("../middleware/authMiddleware");
+const { generateGuildName } = require("../controllers/guildController");
+
+/**
+ * @route   GET /api/guilds/name/generate
+ * @desc    Generate a unique guild name in the form "[adjective] [plural noun]"
+ *          Guaranteed to generate a name that isn't taken yet by a guild.
+ * @access  Protected
+ */
+router.get("/name/generate", authMiddleware, generateGuildName);
+
+module.exports = router;

--- a/backend/routes/leaderboard.js
+++ b/backend/routes/leaderboard.js
@@ -17,7 +17,12 @@ const express = require('express');
 const router = express.Router();
 
 const authMiddleware = require('../middleware/authMiddleware');
-const { getWeeklyLeaderboard, getLifetimeLeaderboard } = require('../controllers/leaderboardController');
+const { 
+        getWeeklyLeaderboard,
+        getLifetimeLeaderboard,
+        getFollowedWeeklyLeaderboard,
+        getFollowedLifetimeLeaderboard,
+      } = require('../controllers/leaderboardController');
 
 /**
  * @route   GET /api/leaderboard/weekly
@@ -32,5 +37,19 @@ router.get('/weekly', authMiddleware, getWeeklyLeaderboard);
  * @access  Protected
  */
 router.get('/lifetime', authMiddleware, getLifetimeLeaderboard);
+
+/**
+ * @route   GET /api/leaderboard/followed/weekly
+ * @desc    Fetch paginated followed users leaderboard ranked by weekly exp
+ * @access  Protected
+ */
+router.get('/followed/weekly', authMiddleware, getFollowedWeeklyLeaderboard);
+
+/**
+ * @route   GET /api/leaderboard/followed/lifetime
+ * @desc    Fetch paginated followed users leaderboard ranked by lifetime exp
+ * @access  Protected
+ */
+router.get('/followed/lifetime', authMiddleware, getFollowedLifetimeLeaderboard);
 
 module.exports = router;

--- a/backend/routes/leaderboard.js
+++ b/backend/routes/leaderboard.js
@@ -22,6 +22,8 @@ const {
         getLifetimeLeaderboard,
         getFollowedWeeklyLeaderboard,
         getFollowedLifetimeLeaderboard,
+        getGuildWeeklyLeaderboard,
+        getGuildLifetimeLeaderboard,
       } = require('../controllers/leaderboardController');
 
 /**
@@ -51,5 +53,19 @@ router.get('/followed/weekly', authMiddleware, getFollowedWeeklyLeaderboard);
  * @access  Protected
  */
 router.get('/followed/lifetime', authMiddleware, getFollowedLifetimeLeaderboard);
+
+/**
+ * @route   GET /api/leaderboard/guilds/weekly
+ * @desc    Fetch all guilds ranked by weekly exp
+ * @access  Protected
+ */
+router.get('/guilds/weekly', authMiddleware, getGuildWeeklyLeaderboard);
+
+/**
+ * @route   GET /api/leaderboard/guilds/lifetime
+ * @desc    Fetch all guilds ranked by lifetime exp
+ * @access  Protected
+ */
+router.get('/guilds/lifetime', authMiddleware, getGuildLifetimeLeaderboard);
 
 module.exports = router;

--- a/backend/routes/myProgress.js
+++ b/backend/routes/myProgress.js
@@ -7,10 +7,14 @@
 //  Description:   User progress tracking routes (history
 //                 table, topic mastery, daily streak).
 //
+//                 Utilizes KnightWise analytics engine
+//
 //  Dependencies:  mysql2 connection pool (req.db)
 //                 express
 //                 authMiddleware
 //                 errorHandler
+//                 paginationConfig
+//                 analyticsModel
 //
 ////////////////////////////////////////////////////////////////
 
@@ -18,50 +22,63 @@ const express = require('express');
 const router = express.Router();
 const authMiddleware = require("../middleware/authMiddleware");
 const { asyncHandler, AppError } = require("../middleware/errorHandler");
+const { PAGE_SIZES } = require('../config/paginationConfig');
+const { computePerformanceMetric, computeWeightedTopicMetric } = require('../utils/analyticsModel');
 
 /**
- * Helper function to process answers and calculate user progress by topic
- * Calculates number of correct answers, total answers, percentage for each topic.
- * 
- * @param {Array<Object>} answers - Array of answer entries from database
- * @returns {Object} Progress data object with topics as keys, {correct, total, percentage} as values
+ * Processes response rows into per-topic performance metrics using the analytics model
+ * Uses point-weighted averaging so higher-point questions influence topic scores more
+ *
+ * @param {Array<Object>} responses - Response rows joined with Question (needs TYPE, SUBCATEGORY)
+ * @returns {Object} Map of topic -> { metric, responseCount }
  */
-const processProgressData = (answers) => {
-  const progress = {};
+const processProgressData = (responses) => {
+  const byTopic       = {}; // topic -> array of per-response metrics
+  const byTopicPoints = {}; // topic -> array of corresponding pointsPossible values
 
-  answers.forEach((answer) => {
-    const topic = answer.TOPIC;
-    const isCorrect = answer.ISCORRECT;
-
+  for (const row of responses)
+  {
+    const topic = row.TOPIC;
     // Initialize topic if not already in progress
-    if (!progress[topic]) 
+    if (!byTopic[topic])
     {
-      progress[topic] = { correct: 0, total: 0 };
+      byTopic[topic]       = [];
+      byTopicPoints[topic] = [];
     }
 
-    // Increment correct/total answers for the topic
-    progress[topic].total += 1;
-    if (isCorrect) 
-    {
-      progress[topic].correct += 1;
-    }
-  });
+    const normalizedScore = row.POINTS_POSSIBLE > 0
+      ? row.POINTS_EARNED / row.POINTS_POSSIBLE
+      : 0;
 
-  // Calculate percentage or other metrics per topic
-  for (const topic in progress) {
-    const { correct, total } = progress[topic];
-    // Prevent division by 0
-    progress[topic].percentage = total > 0 ? ((correct / total) * 100).toFixed(2) : 0;
+    // Compute performance metric
+    byTopic[topic].push(computePerformanceMetric({
+      normalizedScore,
+      elapsedTime: row.ELAPSED_TIME,
+      subcategory: row.SUBCATEGORY,
+      type:        row.TYPE,
+    }));
+
+    // Record points possible for topic weighing
+    byTopicPoints[topic].push(parseFloat(row.POINTS_POSSIBLE));
   }
 
-  return progress;
+  const result = {};
+  for (const [topic, metrics] of Object.entries(byTopic))
+  {
+    result[topic] = {
+      metric:        parseFloat(computeWeightedTopicMetric(metrics, byTopicPoints[topic]).toFixed(4)),
+      responseCount: metrics.length,
+    };
+  }
+
+  return result;
 };
 
 /**
  * @route   GET /api/progress/graph
  * @desc    Get user progress data aggregated by topic for graph visualization
  * @access  Protected
- * 
+ *
  * @param {import('express').Request}  req - Express request object
  * @param {import('express').Response} res - Express response object
  * @returns {Promise<void>} - JSON response with progress data by topic
@@ -76,7 +93,10 @@ router.get('/graph', authMiddleware, asyncHandler(async (req, res) => {
 
   // Fetch user progress data from the database
   const [userAnswers] = await req.db.query(
-    'SELECT * FROM Response WHERE USERID = ?',
+    `SELECT r.*, q.TYPE, q.SUBCATEGORY
+     FROM Response r
+     JOIN Question q ON q.ID = r.PROBLEM_ID
+     WHERE r.USERID = ?`,
     [userId]
   );
 
@@ -86,7 +106,7 @@ router.get('/graph', authMiddleware, asyncHandler(async (req, res) => {
     return res.status(200).json({ progress: {} });
   }
 
-  // Process the data to calculate the user's progress (can aggregate by topic/category)
+  // Process the data to calculate the user's progress
   const progressData = processProgressData(userAnswers);
 
   res.status(200).json({ progress: progressData });
@@ -94,50 +114,44 @@ router.get('/graph', authMiddleware, asyncHandler(async (req, res) => {
 
 /**
  * @route   GET /api/progress/messageData
- * @desc    Get user progress data with history, mastery levels, streak
+ * @desc    Get user progress data with mastery levels, strongest/weakest topics, streak
  * @access  Protected
- * 
+ *
  * @param {import('express').Request}  req - Express request object
  * @param {import('express').Response} res - Express response object
- * @returns {Promise<void>} - JSON response with history, mastery, streak
+ * @returns {Promise<void>} - JSON response with mastery, ranked topics, streak
  */
 router.get("/messageData", authMiddleware, asyncHandler(async (req, res) => {
   const userId = req.user.id;
 
-  // Fetch all answers from the user
+  // JOIN Question so processProgressData has TYPE and SUBCATEGORY
   const [userAnswers] = await req.db.query(
-    'SELECT * FROM Response WHERE USERID = ?',
+    `SELECT r.*, q.TYPE, q.SUBCATEGORY
+     FROM Response r
+     JOIN Question q ON q.ID = r.PROBLEM_ID
+     WHERE r.USERID = ?`,
     [userId]
   );
 
-  // Process history and mastery levels
+  const progressData  = processProgressData(userAnswers);
+  const masteryLevels = Object.fromEntries(
+    Object.entries(progressData).map(([topic, { metric }]) => [topic, metric])
+  );
+
+  const ranked = Object.entries(progressData)
+    .sort(([, a], [, b]) => b.metric - a.metric);
+
+  const strongestTopics = ranked.slice(0, 3).map(([topic]) => topic);
+  const weakestTopics   = ranked.slice(-3).reverse().map(([topic]) => topic);
+
+  // Build history for streak calculation
   const history = userAnswers.map(({ DATETIME, TOPIC }) => ({
     datetime: DATETIME,
-    topic: TOPIC,
+    topic:    TOPIC,
   }));
 
-  // Compute mastery levels
-  const mastery = {};
-  userAnswers.forEach(({ TOPIC, ISCORRECT }) => {
-    if (!mastery[TOPIC]) {
-      mastery[TOPIC] = { correct: 0, total: 0 };
-    }
-    mastery[TOPIC].total += 1;
-    if (ISCORRECT) {
-      mastery[TOPIC].correct += 1;
-    }
-  });
-
-  // Convert mastery to percentage
-  const masteryLevels = {};
-  for (const topic in mastery) {
-    const { correct, total } = mastery[topic];
-    // Prevent division by 0
-    masteryLevels[topic] = total > 0 ? Math.round((correct / total) * 100) : 0;
-  }
-
   // Calculate streak
-  const today = new Date().toDateString();
+  const today      = new Date().toDateString();
   const uniqueDays = new Set();
   userAnswers.forEach(({ DATETIME }) => {
     uniqueDays.add(new Date(DATETIME).toDateString());
@@ -162,7 +176,7 @@ router.get("/messageData", authMiddleware, asyncHandler(async (req, res) => {
     }
   }
 
-  res.status(200).json({ history, mastery: masteryLevels, streak });
+  res.status(200).json({ history, mastery: masteryLevels, strongestTopics, weakestTopics, streak });
 }));
 
 /**
@@ -170,28 +184,27 @@ router.get("/messageData", authMiddleware, asyncHandler(async (req, res) => {
  * @desc    Get paginated user submission history
  *          Includes question type, user answer data, and score data
  * @access  Protected
- * 
+ *
  * @param {import('express').Request}  req - Express request object
  * @param {import('express').Response} res - Express response object
  * @returns {Promise<void>} - JSON response with paginated history
  */
 router.get('/history', authMiddleware, asyncHandler(async (req, res) => {
   const userId = req.user.id;
-  
-  // Pagination logic: default to page 1, limit to 10 results per page
+
+  // Pagination logic: default to page 1
   const page = parseInt(req.query.page) || 1;
-  const limit = 10;
 
   if (page < 1)
   {
     throw new AppError(`Invalid history table page number: ${page}`, 400, "Failed to display history");
   }
 
-  const offset = (page - 1) * limit;  // Calculate the number of results to skip
+  const offset = (page - 1) * PAGE_SIZES.HISTORY_TABLE;
 
   // Join with corresponding Question to get type
   const [history] = await req.db.query(
-    `SELECT 
+    `SELECT
       r.DATETIME,
       r.TOPIC,
       r.ISCORRECT,
@@ -200,20 +213,19 @@ router.get('/history', authMiddleware, asyncHandler(async (req, res) => {
       r.POINTS_EARNED,
       r.POINTS_POSSIBLE,
       q.TYPE
-    FROM Response r 
-    JOIN Question q ON r.PROBLEM_ID = q.ID
-    WHERE r.USERID = ? 
-    ORDER BY r.DATETIME DESC 
-    LIMIT ? OFFSET ?`,
-    [userId, limit, offset]
+     FROM Response r
+     JOIN Question q ON r.PROBLEM_ID = q.ID
+     WHERE r.USERID = ?
+     ORDER BY r.DATETIME DESC
+     LIMIT ? OFFSET ?`,
+    [userId, PAGE_SIZES.HISTORY_TABLE, offset]
   );
 
   // Count the total number of entries for pagination
-  const [countResults] = await req.db.query(
+  const [[{ total: totalEntries }]] = await req.db.query(
     'SELECT COUNT(*) as total FROM Response WHERE USERID = ?',
     [userId]
   );
-  const totalEntries = countResults[0].total;
 
   res.status(200).json({
     history: history.map(row => ({
@@ -228,7 +240,7 @@ router.get('/history', authMiddleware, asyncHandler(async (req, res) => {
     })),
     totalEntries,
     currentPage: page,
-    totalPages: Math.max(1, Math.ceil(totalEntries / limit)),
+    totalPages:  Math.max(1, Math.ceil(totalEntries / PAGE_SIZES.HISTORY_TABLE)),
   });
 }));
 

--- a/backend/routes/myProgress.js
+++ b/backend/routes/myProgress.js
@@ -40,7 +40,8 @@ const processProgressData = (responses) => {
 
   for (const row of responses)
   {
-    const topic = row.TOPIC;
+    // Prevent database inconsistencies from breaking logic
+    const topic = normalizeDBString(row.TOPIC);
     // Initialize topic if not already in progress
     if (!byTopic[topic])
     {
@@ -56,8 +57,8 @@ const processProgressData = (responses) => {
     byTopic[topic].push(computePerformanceMetric({
       normalizedScore,
       elapsedTime: row.ELAPSED_TIME,
-      subcategory: row.SUBCATEGORY,
-      type:        row.TYPE,
+      subcategory: normalizeDBString(row.SUBCATEGORY ?? ''),
+      type:        normalizeDBString(row.TYPE ?? ''),
     }));
 
     // Record points possible for topic weighing
@@ -149,7 +150,7 @@ router.get("/messageData", authMiddleware, asyncHandler(async (req, res) => {
   // Build history for streak calculation
   const history = userAnswers.map(({ DATETIME, TOPIC }) => ({
     datetime: DATETIME,
-    topic:    TOPIC,
+    topic:    normalizeDBString(TOPIC),
   }));
 
   // Calculate streak

--- a/backend/routes/stats.js
+++ b/backend/routes/stats.js
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          stats.js
+//  Description:   Express routes for aggregate analytics endpoints.
+//                 Restricted to professors and admins.
+//
+//  Dependencies:  express
+//                 adminOrProf
+//                 statsController
+//
+////////////////////////////////////////////////////////////////
+
+const express = require('express');
+const router  = express.Router();
+
+const adminOrProf = require('../middleware/adminOrProf');
+const {
+  getAggregateStats,
+  getAggregateStatsByQuestion,
+} = require('../controllers/statsController');
+
+/**
+ * @route   GET /api/stats/aggregate
+ * @desc    Aggregate stats across all opted-in users
+ * @access  Professor, Admin
+ */
+router.get('/aggregate', adminOrProf, getAggregateStats);
+
+/**
+ * @route   GET /api/stats/aggregate/:questionId
+ * @desc    Aggregate stats for a single question across all opted-in users
+ * @access  Professor, Admin
+ */
+router.get('/aggregate/:questionId', adminOrProf, getAggregateStatsByQuestion);
+
+module.exports = router;

--- a/backend/routes/testRoutes.js
+++ b/backend/routes/testRoutes.js
@@ -206,7 +206,7 @@ router.get("/mocktest", authMiddleware, asyncHandler(async (req, res) => {
  * @returns {Promise<void>} - JSON response to confirm successful submission
  */
 router.post("/submit", authMiddleware, asyncHandler(async (req, res) => {
-  const { problem_id, userAnswer, category, topic } = req.body;
+  const { problem_id, userAnswer, category, topic, elapsedTime } = req.body;
   const user_id = req.user.id;
 
   // Get question by ID, we care about question type and points
@@ -246,9 +246,10 @@ router.post("/submit", authMiddleware, asyncHandler(async (req, res) => {
       POINTS_POSSIBLE,
       CATEGORY,
       TOPIC,
+      ELAPSED_TIME,
       DATETIME
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       user_id,
       problem_id,
@@ -258,6 +259,7 @@ router.post("/submit", authMiddleware, asyncHandler(async (req, res) => {
       result.pointsPossible,
       category,
       topic,
+      elapsedTime ?? null,
       new Date()
     ]
   );

--- a/backend/routes/testRoutes.js
+++ b/backend/routes/testRoutes.js
@@ -22,7 +22,7 @@ const router = express.Router();
 const authMiddleware = require("../middleware/authMiddleware");
 const { asyncHandler, AppError } = require("../middleware/errorHandler");
 const { gradeQuestion } = require("../controllers/gradingController");
-const { awardCurrency } = require("../utils/currencyUtils");
+const { awardCurrency, awardGuildExp } = require("../utils/currencyUtils");
 const { getProgrammingSubmissionsRemaining } = require("../config/codeLimits");
 
 /**
@@ -265,7 +265,9 @@ router.post("/submit", authMiddleware, asyncHandler(async (req, res) => {
   );
 
   // Award currency to user (respects daily exp cap)
+  // Also award exp to user's guild if they're in one
   await awardCurrency(req.db, user_id, result.pointsEarned);
+  await awardGuildExp(req.db, user_id, result.pointsEarned);
 
   res.status(201).json(
   { 

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -26,7 +26,22 @@ const {
         unequipItem,
         followUser,
         unfollowUser,
+        searchUsers
       } = require("../controllers/userController");
+
+/**
+ * @route   GET /api/users/search
+ * @desc    Search users by username (partial, case-insensitive), paginated
+ *          Call with username and page as query parameters
+ * @access  Protected
+ */
+router.get("/search", authMiddleware, searchUsers);
+
+//////////////////////////////////////////////////////////////////////////////////////
+//
+//   ##### ALL NON-WILDCARD ROUTES MUST GO BEFORE THESE WILDCARD (/:id) ROUTES #####
+//
+//////////////////////////////////////////////////////////////////////////////////////
 
 /**
  * @route   DELETE /api/users/:id

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -24,6 +24,8 @@ const {
         getPurchases,
         equipItem,
         unequipItem,
+        followUser,
+        unfollowUser,
       } = require("../controllers/userController");
 
 /**
@@ -67,5 +69,19 @@ router.put("/:id/equip", authMiddleware, equipItem);
  * @access  Protected
  */
 router.put("/:id/unequip", authMiddleware, unequipItem);
+
+/**
+ * @route   POST /api/users/:id/follow
+ * @desc    Follow the user with the given ID
+ * @access  Protected
+ */
+router.post("/:id/follow", authMiddleware, followUser);
+
+/**
+ * @route   DELETE /api/users/:id/follow
+ * @desc    Unfollow the user with the given ID
+ * @access  Protected
+ */
+router.delete("/:id/follow", authMiddleware, unfollowUser);
 
 module.exports = router;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -10,6 +10,7 @@
 //  Dependencies:  express
 //                 authMiddleware
 //                 userController
+//                 guildController
 //
 ////////////////////////////////////////////////////////////////
 
@@ -29,6 +30,7 @@ const {
         searchUsers,
         updateStatsOptIn,
       } = require("../controllers/userController");
+const { getMyInvites } = require('../controllers/guildController');
 
 /**
  * @route   GET /api/users/search
@@ -37,6 +39,14 @@ const {
  * @access  Protected
  */
 router.get("/search", authMiddleware, searchUsers);
+
+/**
+ * @route   GET /api/users/me/guild-invites
+ * @desc    Search users by username (partial, case-insensitive), paginated
+ *          Call with username and page as query parameters
+ * @access  Protected
+ */
+router.get('/me/guild-invites', authMiddleware, getMyInvites);
 
 //////////////////////////////////////////////////////////////////////////////////////
 //

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -26,7 +26,8 @@ const {
         unequipItem,
         followUser,
         unfollowUser,
-        searchUsers
+        searchUsers,
+        updateStatsOptIn,
       } = require("../controllers/userController");
 
 /**
@@ -98,5 +99,12 @@ router.post("/:id/follow", authMiddleware, followUser);
  * @access  Protected
  */
 router.delete("/:id/follow", authMiddleware, unfollowUser);
+
+/**
+ * @route   PUT /api/users/:id/stats-opt-in
+ * @desc    Toggle IS_SHARING_STATS for the user
+ * @access  Protected
+ */
+router.put("/:id/stats-opt-in", authMiddleware, updateStatsOptIn);
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -105,6 +105,7 @@ app.use('/api/code', require('./routes/codeSubmission'));
 app.use('/api/profauth', require('./routes/profAuthRoutes'));
 app.use('/api/store', require('./routes/store'));
 app.use('/api/leaderboard', require('./routes/leaderboard'));
+app.use('/api/guilds', require('./routes/guilds'));
 
 // Start background jobs (skip during tests)
 if (process.env.NODE_ENV !== 'test')

--- a/backend/server.js
+++ b/backend/server.js
@@ -106,6 +106,7 @@ app.use('/api/profauth', require('./routes/profAuthRoutes'));
 app.use('/api/store', require('./routes/store'));
 app.use('/api/leaderboard', require('./routes/leaderboard'));
 app.use('/api/guilds', require('./routes/guilds'));
+app.use('/api/stats', require('./routes/stats'));
 
 // Start background jobs (skip during tests)
 if (process.env.NODE_ENV !== 'test')

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -573,6 +573,56 @@ paths:
         500:
           description: Server Error
 
+  /leaderboard/followed/weekly:
+    get:
+      tags:
+        - Users
+      summary: Fetch followed users weekly exp leaderboard.
+      operationId: getFollowedWeeklyLeaderboard
+      description: Returns users that the requesting user follows, ranked by weekly exp using DENSE_RANK, paginated at PAGE_SIZE users per page. Includes the requesting user's rank and exp within the global pool regardless of current page. Returns an empty leaderboard if the requesting user follows nobody.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          type: integer
+          description: Page number (default 1, PAGE_SIZE users per page, clamped to valid range)
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/LeaderboardResponse'
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+
+  /leaderboard/followed/lifetime:
+    get:
+      tags:
+        - Users
+      summary: Fetch followed users lifetime exp leaderboard.
+      operationId: getFollowedLifetimeLeaderboard
+      description: Returns users that the requesting user follows, ranked by lifetime exp using DENSE_RANK, paginated at PAGE_SIZE users per page. Includes the requesting user's rank and exp within the global pool regardless of current page. Returns an empty leaderboard if the requesting user follows nobody.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          type: integer
+          description: Page number (default 1, PAGE_SIZE users per page, clamped to valid range)
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/LeaderboardResponse'
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+
   /admin/createquestion:
     post:
       tags:

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -256,12 +256,32 @@ paths:
           in: query
           required: false
           type: integer
-          description: Page number (default 1, PAGE_SIZES.USER_SEARCH page size per page, clamped to valid range).
+          description: Page number (default 1, PAGE_SIZES.USER_SEARCH per page, clamped to valid range).
       responses:
         200:
           description: OK
           schema:
             $ref: '#/definitions/UserSearchResponse'
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+
+  /users/me/guild-invites:
+    get:
+      tags:
+        - Users
+        - Guilds
+      summary: Fetch pending guild invites for the current user.
+      operationId: getMyInvites
+      description: Returns all pending guild invites sent to the requesting user. Visible to any authenticated user regardless of guild membership.
+      security:
+        - BearerAuth: []
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/GuildInvitesResponse'
         401:
           description: Unauthorized
         500:
@@ -754,6 +774,564 @@ paths:
         500:
           description: Server Error
 
+  /leaderboard/guilds/weekly:
+    get:
+      tags:
+        - Guilds
+      summary: Fetch weekly exp guild leaderboard.
+      operationId: getGuildWeeklyLeaderboard
+      description: |
+        Returns guilds ranked by weekly exp using DENSE_RANK, paginated at PAGE_SIZES.LEADERBOARD_GUILD guilds per page.
+        - Includes the requesting user's guild rank and exp regardless of current page.
+        - Returns null guildRank, guildExp, and guildId if the requesting user is not in a guild.
+        - Weekly exp resets every Monday at midnight UTC.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          type: integer
+          description: Page number (default 1, PAGE_SIZES.LEADERBOARD_GUILD guilds per page, clamped to valid range)
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/GuildLeaderboardResponse'
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+
+  /leaderboard/guilds/lifetime:
+    get:
+      tags:
+        - Guilds
+      summary: Fetch lifetime exp guild leaderboard.
+      operationId: getGuildLifetimeLeaderboard
+      description: |
+        Returns guilds ranked by lifetime exp using DENSE_RANK, paginated at PAGE_SIZES.LEADERBOARD_GUILD guilds per page.
+        - Includes the requesting user's guild rank and exp regardless of current page.
+        - Returns null guildRank, guildExp, and guildId if the requesting user is not in a guild.
+        - Lifetime exp never resets.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          type: integer
+          description: Page number (default 1, PAGE_SIZES.LEADERBOARD_GUILD guilds per page, clamped to valid range)
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/GuildLeaderboardResponse'
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+
+  /guilds/name/generate:
+    get:
+      tags:
+        - Guilds
+      summary: Generate a random guild name.
+      operationId: generateGuildName
+      description: |
+        Returns a randomly generated guild name composed of an adjective and a plural noun from the backend word bank.
+        - Guaranteed to return a name not already in use.
+        - Intended to be called repeatedly during guild creation while the user shuffles names.
+        - The name is not persisted until POST /guilds is called.
+      security:
+        - BearerAuth: []
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/GuildNameResponse'
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+        503:
+          description: All possible guild name combinations are in use
+
+  /guilds:
+    post:
+      tags:
+        - Guilds
+      summary: Create a new guild.
+      operationId: createGuild
+      description: |
+        Creates a new guild with the requesting user as Owner.
+        - Atomically inserts Guild and GuildMember rows in a transaction.
+        - User must not already be in a guild.
+        - Guild name must be unique.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: body
+          name: createGuildItem
+          description: Guild creation details.
+          schema:
+            $ref: '#/definitions/CreateGuild'
+      responses:
+        201:
+          description: Created
+          schema:
+            $ref: '#/definitions/CreateGuildResponse'
+        400:
+          description: Bad Request - Missing or empty name
+        401:
+          description: Unauthorized
+        409:
+          description: Conflict - User already in a guild, or name already taken
+        500:
+          description: Server Error
+
+  /guilds/{id}:
+    get:
+      tags:
+        - Guilds
+      summary: Fetch guild info.
+      operationId: getGuildInfo
+      description: Returns guild info alongside currently equipped guild items. Mirrors getUserInfo structure.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/GuildInfoResponse'
+        400:
+          description: Bad Request - Invalid guild ID
+        401:
+          description: Unauthorized
+        404:
+          description: Guild Not Found
+        500:
+          description: Server Error
+    delete:
+      tags:
+        - Guilds
+      summary: Delete a guild.
+      operationId: deleteGuild
+      description: Deletes the guild and cascades to all associated GuildMember and GuildEntry rows. Owner only.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Invalid guild ID
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Owner only
+        404:
+          description: Guild Not Found
+        500:
+          description: Server Error
+
+  /guilds/{id}/leave:
+    delete:
+      tags:
+        - Guilds
+      summary: Leave a guild.
+      operationId: leaveGuild
+      description: |
+        Removes the requesting user from the guild. Member or Officer only.
+        - Owners cannot leave, they must delete the guild instead.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Invalid guild ID
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Owners cannot leave; non-members cannot leave
+        404:
+          description: Guild Not Found
+        500:
+          description: Server Error
+
+  /guilds/{id}/contribute:
+    post:
+      tags:
+        - Guilds
+      summary: Contribute coins to guild bank.
+      operationId: contributeCoins
+      description: |
+        Deducts coins from the requesting user's balance and adds them to the guild coin bank atomically.
+        - Any guild member may contribute.
+        - After contribution, automatically unlocks any guild store items whose coin threshold (StoreItem.COST) is now met.
+        - Returns the updated coin bank total and any newly unlocked items.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+        - in: body
+          name: contributeItem
+          description: Contribution details.
+          schema:
+            $ref: '#/definitions/ContributeCoins'
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/ContributeCoinsResponse'
+        400:
+          description: Bad Request - Invalid amount or insufficient coins
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Must be a guild member
+        404:
+          description: Guild Not Found
+        500:
+          description: Server Error
+
+  /guilds/{id}/members/{userId}:
+    delete:
+      tags:
+        - Guilds
+      summary: Kick a member from the guild.
+      operationId: kickMember
+      description: |
+        Removes a member from the guild. Officer or Owner only.
+        - Owner can kick any Member or Officer.
+        - Officer can kick Members only, not other Officers or the Owner.
+        - Owner cannot kick themselves, delete the guild instead.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+        - name: userId
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the member to kick.
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Invalid IDs or Owner attempting to kick themselves
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Insufficient role to kick target
+        404:
+          description: Guild or member not found
+        500:
+          description: Server Error
+
+  /guilds/{id}/members/{userId}/role:
+    patch:
+      tags:
+        - Guilds
+      summary: Promote or demote a guild member.
+      operationId: updateMemberRole
+      description: |
+        Changes a guild member's role. Officer or Owner only.
+        - Owner can promote Members to Officer and demote Officers to Member.
+        - Officer can only promote Members to Officer. Cannot demote.
+        - Owner role cannot be changed via this endpoint.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+        - name: userId
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the member to promote or demote.
+        - in: body
+          name: updateRoleItem
+          description: New role to assign.
+          schema:
+            $ref: '#/definitions/UpdateMemberRole'
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Invalid IDs or invalid role value
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Insufficient role or attempting to change Owner role
+        404:
+          description: Guild or member not found
+        500:
+          description: Server Error
+
+  /guilds/{id}/equip:
+    put:
+      tags:
+        - Guilds
+      summary: Equip an unlocked guild item.
+      operationId: equipGuildItem
+      description: |
+        Equips an unlocked guild store item. Officer or Owner only.
+        - Item must have been unlocked via coin contribution threshold before equipping.
+        - Auto-swaps for item types with an equip limit of 1 (e.g. guild profile picture).
+        - Returns 409 if equip limit exceeded for types with limit greater than 1.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+        - in: body
+          name: equipGuildItem
+          description: Item to equip.
+          schema:
+            $ref: '#/definitions/EquipItem'
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Item already equipped
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Officer or Owner only, or item not unlocked
+        404:
+          description: Guild or item not found
+        409:
+          description: Conflict - Equip limit reached for item type
+        500:
+          description: Server Error
+
+  /guilds/{id}/unequip:
+    put:
+      tags:
+        - Guilds
+      summary: Unequip an equipped guild item.
+      operationId: unequipGuildItem
+      description: Unequips a currently equipped guild store item. Officer or Owner only.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+        - in: body
+          name: unequipGuildItem
+          description: Item to unequip.
+          schema:
+            $ref: '#/definitions/EquipItem'
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Item not currently equipped
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Officer or Owner only, or item not unlocked
+        404:
+          description: Guild or item not found
+        500:
+          description: Server Error
+
+  /guilds/{id}/invite:
+    post:
+      tags:
+        - Guilds
+      summary: Invite a user to the guild.
+      operationId: inviteUser
+      description: |
+        Creates a GuildEntry record of type INVITE for the target user. Officer or Owner only.
+        - Target must not already be a member of this guild.
+        - Inviting an already-invited user is idempotent.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+        - in: body
+          name: inviteItem
+          description: Invite details.
+          schema:
+            $ref: '#/definitions/GuildInvite'
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Target is already a member or invalid IDs
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Officer or Owner only
+        404:
+          description: Guild or target user not found
+        500:
+          description: Server Error
+
+  /guilds/{id}/request:
+    post:
+      tags:
+        - Guilds
+      summary: Request to join a guild.
+      operationId: requestToJoin
+      description: |
+        Creates a GuildEntry record of type REQUEST for the requesting user.
+        - Guild must have IS_OPEN = true to accept join requests.
+        - User must not already be a member of this guild.
+        - Guild owners cannot request to join another guild, they must delete their guild first (returns 409).
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Already a member of this guild
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Guild is not open to join requests
+        404:
+          description: Guild Not Found
+        409:
+          description: Conflict - Requesting user owns a guild and must delete it first
+        500:
+          description: Server Error
+
+  /guilds/{id}/entry/{userId}:
+    patch:
+      tags:
+        - Guilds
+      summary: Accept or reject a guild entry.
+      operationId: resolveEntry
+      description: |
+        Accepts or rejects a pending guild invite or join request.
+
+        **For INVITE**: The accepting/rejecting party must be the invitee.
+
+        **For REQUEST**: The accepting/rejecting party must be an Officer or Owner.
+
+        **On rejection**: GuildEntry row is deleted, no membership change.
+
+        **On acceptance**: GuildEntry row deleted and GuildMember row inserted atomically. Handles three membership state transitions:
+        - No existing guild: user is inserted as Member directly.
+        - Member or Officer of another guild: returns `requiresConfirmation: true` without taking action. Resubmit with `confirmLeave: true` to atomically leave the old guild and join the new one.
+        - Owner of another guild: rejected with 409. User must delete their guild first.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+        - name: userId
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the user whose entry is being resolved.
+        - in: body
+          name: resolveEntryItem
+          description: Resolution details.
+          schema:
+            $ref: '#/definitions/ResolveEntry'
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/ResolveEntryResponse'
+        400:
+          description: Bad Request - Invalid IDs or invalid action value
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Not authorized to act on this entry
+        404:
+          description: Guild or entry not found
+        409:
+          description: Conflict - Target owns another guild, or guild is at max size
+        500:
+          description: Server Error
+
+  /guilds/{id}/requests:
+    get:
+      tags:
+        - Guilds
+      summary: Fetch pending join requests for a guild.
+      operationId: getGuildRequests
+      description: Returns all pending REQUEST type GuildEntry records for the guild. Officer or Owner only.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/GuildRequestsResponse'
+        400:
+          description: Bad Request - Invalid guild ID
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Officer or Owner only
+        404:
+          description: Guild Not Found
+        500:
+          description: Server Error
+
   /admin/createquestion:
     post:
       tags:
@@ -935,7 +1513,7 @@ paths:
       - Admins
       - Professors
       summary: Fetch published question metadata.
-      operationId: getQuestionsByStatus
+      operationId: getQuestionsByStatus2
       description: Returns metadata for all published questions. Professors see only their own published questions. Admins see all published questions.
       security:
         - BearerAuth: []
@@ -1074,7 +1652,6 @@ paths:
           description: Professor Not Found
         500:
           description: Server Error
-  
 
   /code/submitCode:
     post:
@@ -1260,16 +1837,16 @@ paths:
       - Users
       summary: Fetch user progress data for graph.
       operationId: getGraphData
-      description: Retrieves user performance data for a radar chart visualization.
+      description: Retrieves user performance data for a radar chart visualization using the KnightWise analytics engine. Returns per-topic weighted performance metrics.
       security:
         - BearerAuth: []
       responses:
         200:
           description: OK
+          schema:
+            $ref: '#/definitions/ProgressGraphResponse'
         401:
           description: Unauthorized
-        404: 
-          description: URL Not Found
         500:
           description: Server Error
   
@@ -1302,46 +1879,19 @@ paths:
       - Users
       summary: Fetch user progress message data.
       operationId: getMessage
-      description: Generates a message that recommends practice topics and records the user's streak.
+      description: Returns mastery levels, strongest and weakest topics, and streak data using the KnightWise analytics engine.
       security:
         - BearerAuth: []
-      responses:
-        200:
-          description: OK
-        401:
-          description: Unauthorized
-        404:
-          description: URL Not Found
-        500:
-          description: Server Error
-
-  /guilds/name/generate:
-    get:
-      tags:
-        - Guilds
-      summary: Generate a random guild name.
-      operationId: generateGuildName
-      description: |
-        Returns a randomly generated guild name composed of an adjective and a plural noun from the backend word bank.
-        - Guaranteed to return a name not already in use.
-        - Intended to be called repeatedly during guild creation while the user shuffles names.
-        - The name is not persisted until POST /guilds is called.
-      security:
-        - BearerAuth: []
-      produces:
-        - application/json
       responses:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/GuildNameResponse'
+            $ref: '#/definitions/MessageDataResponse'
         401:
           description: Unauthorized
         500:
           description: Server Error
-        503:
-          description: All possible guild name combinations are in use
-          
+
 securityDefinitions:
   BearerAuth:
     type: apiKey
@@ -1580,6 +2130,10 @@ definitions:
         type: boolean
         example: false
         description: If true, runs against first test case only without grading or saving. If false, runs full graded submission.
+      elapsedTime:
+        type: integer
+        example: 45
+        description: Time in seconds from question display to submission. Optional, null if not provided.
   
   SubmitAnswer:
     type: object
@@ -1881,12 +2435,249 @@ definitions:
               nullable: true
         description: "Page of users ranked by exp. Tied users share the same rank. PAGE_SIZES.LEADERBOARD users per page."
 
+  GuildLeaderboardResponse:
+    type: object
+    properties:
+      guildRank:
+        type: integer
+        example: 2
+        nullable: true
+        description: Requesting user's guild rank. Null if user is not in a guild.
+      guildExp:
+        type: number
+        example: 600
+        nullable: true
+        description: Requesting user's guild exp value. Null if user is not in a guild.
+      guildId:
+        type: integer
+        example: 7
+        nullable: true
+        description: Requesting user's guild ID. Null if user is not in a guild.
+      page:
+        type: integer
+        example: 1
+        description: Current page number.
+      totalPages:
+        type: integer
+        example: 1
+        description: Total number of pages at PAGE_SIZES.LEADERBOARD_GUILD guilds per page.
+      leaderboard:
+        type: array
+        items:
+          type: object
+          properties:
+            rank:
+              type: integer
+              example: 1
+            id:
+              type: integer
+              example: 3
+            name:
+              type: string
+              example: "Ancient Wolves"
+            exp:
+              type: number
+              example: 9000
+            guildPicture:
+              type: string
+              example: "Golden Shield"
+              nullable: true
+        description: "Page of guilds ranked by exp. Tied guilds share the same rank. PAGE_SIZES.LEADERBOARD_GUILD guilds per page."
+
   GuildNameResponse:
     type: object
     properties:
       name:
         type: string
         example: "Blazing Dragons"
+
+  CreateGuild:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        example: "Ancient Wolves"
+        description: The name for the new guild. Must be unique.
+
+  CreateGuildResponse:
+    type: object
+    properties:
+      message:
+        type: string
+        example: "Guild created successfully"
+      guildId:
+        type: integer
+        example: 7
+
+  GuildInfoResponse:
+    type: object
+    properties:
+      guild:
+        type: object
+        properties:
+          ID:
+            type: integer
+            example: 7
+          NAME:
+            type: string
+            example: "Ancient Wolves"
+          OWNER_ID:
+            type: integer
+            example: 1
+          LIFETIME_EXP:
+            type: number
+            example: 5000.0
+          WEEKLY_EXP:
+            type: number
+            example: 800.0
+          DAILY_EXP:
+            type: number
+            example: 120.0
+          COINS:
+            type: number
+            example: 2500.0
+          ESTABLISHED:
+            type: string
+            example: "2026-01-15T00:00:00.000Z"
+          IS_OPEN:
+            type: integer
+            example: 1
+            description: "1 if guild is accepting join requests, 0 if not."
+      equippedItems:
+        type: array
+        items:
+          $ref: '#/definitions/StoreItem'
+        description: Currently equipped guild store items.
+
+  ContributeCoins:
+    type: object
+    required:
+      - amount
+    properties:
+      amount:
+        type: number
+        example: 100
+        description: Number of coins to contribute. Must be a positive number and cannot exceed user's current balance.
+
+  ContributeCoinsResponse:
+    type: object
+    properties:
+      message:
+        type: string
+        example: "Contribution successful"
+      coinBank:
+        type: number
+        example: 2600
+        description: Updated guild coin bank total after contribution.
+      newlyUnlocked:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: integer
+              example: 5
+            name:
+              type: string
+              example: "Guild Banner"
+            type:
+              type: string
+              example: "flair"
+        description: Guild store items newly unlocked by this contribution. Empty array if none.
+
+  UpdateMemberRole:
+    type: object
+    required:
+      - newRole
+    properties:
+      newRole:
+        type: string
+        example: "Officer"
+        description: "New role to assign. Must be 'Member' or 'Officer'. Owner role cannot be assigned via this endpoint."
+
+  GuildInvite:
+    type: object
+    required:
+      - targetUserId
+    properties:
+      targetUserId:
+        type: integer
+        example: 42
+        description: The unique ID of the user to invite.
+
+  ResolveEntry:
+    type: object
+    required:
+      - action
+    properties:
+      action:
+        type: string
+        example: "accept"
+        description: "Must be 'accept' or 'reject'."
+      confirmLeave:
+        type: boolean
+        example: true
+        description: |
+          Required only when accepting and the target user is already a member of another guild.
+          Set to true to confirm leaving the old guild and joining the new one atomically.
+          If omitted when required, the response will include requiresConfirmation: true and no action will be taken.
+
+  ResolveEntryResponse:
+    type: object
+    properties:
+      message:
+        type: string
+        example: "Entry accepted, user is now a guild member"
+      requiresConfirmation:
+        type: boolean
+        example: true
+        nullable: true
+        description: |
+          Present and true only when the target user is already in another guild and confirmLeave was not provided.
+          Frontend should prompt the user to confirm leaving their current guild before resubmitting with confirmLeave: true.
+
+  GuildInvitesResponse:
+    type: object
+    properties:
+      invites:
+        type: array
+        items:
+          type: object
+          properties:
+            GUILD_ID:
+              type: integer
+              example: 7
+            guildName:
+              type: string
+              example: "Ancient Wolves"
+            OWNER_ID:
+              type: integer
+              example: 1
+
+  GuildRequestsResponse:
+    type: object
+    properties:
+      requests:
+        type: array
+        items:
+          type: object
+          properties:
+            USER_ID:
+              type: integer
+              example: 42
+            USERNAME:
+              type: string
+              example: "knightking"
+            FIRSTNAME:
+              type: string
+              example: "Arthur"
+              nullable: true
+            LASTNAME:
+              type: string
+              example: "Pendragon"
+              nullable: true
 
   StatsOptIn:
     type: object
@@ -1963,6 +2754,61 @@ definitions:
         type: integer
         example: 3
         description: Number of opted-in responses for this question.
+
+  ProgressGraphResponse:
+    type: object
+    properties:
+      progress:
+        type: object
+        description: Map of topic name to performance metric data. Keys are Response.TOPIC strings.
+        additionalProperties:
+          type: object
+          properties:
+            metric:
+              type: number
+              example: 0.7342
+              description: Point-weighted performance metric from 0.0 to 1.0. Higher is better.
+            responseCount:
+              type: integer
+              example: 12
+              description: Number of responses contributing to this topic's metric.
+
+  MessageDataResponse:
+    type: object
+    properties:
+      history:
+        type: array
+        items:
+          type: object
+          properties:
+            datetime:
+              type: string
+              example: "2026-03-15T14:30:00.000Z"
+            topic:
+              type: string
+              example: "Arrays"
+      mastery:
+        type: object
+        description: Map of topic name to weighted performance metric (0.0 to 1.0).
+        additionalProperties:
+          type: number
+          example: 0.6821
+      strongestTopics:
+        type: array
+        items:
+          type: string
+        example: ["Trees", "Recursion", "Sorting"]
+        description: Up to 3 topics with the highest performance metrics.
+      weakestTopics:
+        type: array
+        items:
+          type: string
+        example: ["Variables", "InputOutput", "Branching"]
+        description: Up to 3 topics with the lowest performance metrics.
+      streak:
+        type: integer
+        example: 5
+        description: Number of consecutive days the user has submitted at least one answer.
 
 host: www.knightwise.dev
 basePath: /api

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -1081,6 +1081,33 @@ paths:
           description: URL Not Found
         500:
           description: Server Error
+
+  /guilds/name/generate:
+    get:
+      tags:
+        - Guilds
+      summary: Generate a random guild name.
+      operationId: generateGuildName
+      description: |
+        Returns a randomly generated guild name composed of an adjective and a plural noun from the backend word bank.
+        - Guaranteed to return a name not already in use.
+        - Intended to be called repeatedly during guild creation while the user shuffles names.
+        - The name is not persisted until POST /guilds is called.
+      security:
+        - BearerAuth: []
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/GuildNameResponse'
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+        503:
+          description: All possible guild name combinations are in use
           
 securityDefinitions:
   BearerAuth:
@@ -1574,6 +1601,13 @@ definitions:
               example: "Octocat"
               nullable: true
         description: "Page of users ranked by exp. Tied users share the same rank. PAGE_SIZE users per page."
+
+  GuildNameResponse:
+    type: object
+    properties:
+      name:
+        type: string
+        example: "Blazing Dragons"
 
 host: www.knightwise.dev
 basePath: /api

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -1332,6 +1332,46 @@ paths:
         500:
           description: Server Error
 
+  /guilds/{id}/open:
+    patch:
+      tags:
+        - Guilds
+      summary: Update guild open/closed status.
+      operationId: updateGuildOpen
+      description: |
+        Sets whether the guild accepts join requests.
+        - When open (IS_OPEN = true), any authenticated user can submit a join request.
+        - When closed (IS_OPEN = false), join requests are blocked with 403.
+        - Officer or Owner only.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the guild.
+        - in: body
+          name: updateGuildOpenItem
+          description: Desired open state.
+          schema:
+            $ref: '#/definitions/UpdateGuildOpen'
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/UpdateGuildOpenResponse'
+        400:
+          description: Bad Request - Invalid guild ID or isOpen is not a boolean
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Officer or Owner only
+        404:
+          description: Guild Not Found
+        500:
+          description: Server Error
+
   /admin/createquestion:
     post:
       tags:
@@ -1369,6 +1409,36 @@ paths:
           description: Bad Request - Missing fields, invalid item type, or negative cost
         401:
           description: Unauthorized
+        500:
+          description: Server Error
+
+  /admin/store/items/{id}:
+    delete:
+      tags:
+        - Admins
+      summary: Delete a store item.
+      operationId: deleteStoreItem
+      description: |
+        Deletes a store item by ID. Admin only.
+        - Cascades to all associated Purchase and GuildUnlock rows.
+        - Use with caution, deleting an item removes it from all users who have purchased it.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the store item to delete.
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Invalid item ID
+        401:
+          description: Unauthorized
+        404:
+          description: Item Not Found
         500:
           description: Server Error
 
@@ -2344,6 +2414,10 @@ definitions:
       NAME:
         type: string
         example: "Greatest of all Time"
+      IS_GUILD_ITEM:
+        type: integer
+        example: 0
+        description: "1 if this is a guild store item, 0 if it is a user store item."
 
   StoreItemsResponse:
     type: object
@@ -2381,6 +2455,10 @@ definitions:
       itemName:
         type: string
         example: "Greatest of all Time"
+      isGuildItem:
+        type: boolean
+        example: false
+        description: "If true, item appears in the guild store and can be unlocked via coin contribution. Defaults to false."
 
   CreateStoreItemResponse:
     type: object
@@ -2550,6 +2628,58 @@ definitions:
         items:
           $ref: '#/definitions/StoreItem'
         description: Currently equipped guild store items.
+      members:
+        type: array
+        items:
+          $ref: '#/definitions/GuildMember'
+        description: Guild members ordered by role (Owner, Officer, Member) then username.
+      unlockedItems:
+        type: array
+        items:
+          $ref: '#/definitions/GuildUnlockedItem'
+        description: All store items unlocked by the guild via coin contribution, including equipped and unequipped.
+
+  UpdateGuildOpen:
+    type: object
+    required:
+      - isOpen
+    properties:
+      isOpen:
+        type: boolean
+        example: true
+        description: True to allow join requests, false to block them.
+
+  UpdateGuildOpenResponse:
+    type: object
+    properties:
+      message:
+        type: string
+        example: "Guild is now open to join requests"
+      isOpen:
+        type: boolean
+        example: true
+
+  GuildUnlockedItem:
+    type: object
+    properties:
+      ID:
+        type: integer
+        example: 1
+      TYPE:
+        type: string
+        example: "profile_picture"
+        description: "Item type. One of: flair, profile_picture, background"
+      COST:
+        type: string
+        example: "100.00"
+        description: "Coin threshold required to unlock. Returned as string due to MySQL DECIMAL serialization."
+      NAME:
+        type: string
+        example: "Golden Shield"
+      IS_EQUIPPED:
+        type: integer
+        example: 0
+        description: "1 if currently equipped by the guild, 0 if unlocked but not equipped."
 
   ContributeCoins:
     type: object
@@ -2678,6 +2808,37 @@ definitions:
               type: string
               example: "Pendragon"
               nullable: true
+
+  GuildMember:
+    type: object
+    properties:
+      ID:
+        type: integer
+        example: 1
+      USERNAME:
+        type: string
+        example: "knightking"
+        nullable: true
+      FIRSTNAME:
+        type: string
+        example: "Arthur"
+        nullable: true
+      LASTNAME:
+        type: string
+        example: "Pendragon"
+        nullable: true
+      ROLE:
+        type: string
+        example: "Officer"
+        description: "Guild role. One of: Owner, Officer, Member"
+      COINS_CONTRIBUTED:
+        type: number
+        example: 250.0
+        description: Total coins this member has contributed to the guild bank.
+      JOINED:
+        type: string
+        example: "2026-01-15T00:00:00.000Z"
+        description: UTC datetime when the member joined the guild.
 
   StatsOptIn:
     type: object

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -233,6 +233,40 @@ paths:
         500:
           description: Server Error
 
+  /users/search:
+    get:
+      tags:
+        - Users
+      summary: Search users by username.
+      operationId: searchUsers
+      description: |
+        Returns a paginated list of users whose username partially matches the query string.
+        - Match is case-insensitive. Empty or omitted username returns all users.
+        - Invalid or out-of-range page values are clamped to a valid page rather than rejected.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: username
+          in: query
+          required: false
+          type: string
+          description: Partial, case-insensitive username to search for. Omit or leave empty to return all users.
+          example: knight
+        - name: page
+          in: query
+          required: false
+          type: integer
+          description: Page number (default 1, PAGE_SIZES.USER_SEARCH page size per page, clamped to valid range).
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/UserSearchResponse'
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+
   /users/{id}:
     get:
       tags:
@@ -529,7 +563,7 @@ paths:
         - Users
       summary: Fetch weekly exp leaderboard.
       operationId: getWeeklyLeaderboard
-      description: Returns users ranked by weekly exp using DENSE_RANK, paginated at PAGE_SIZE users per page. Includes the requesting user's rank and exp regardless of current page. Weekly exp resets every Monday at midnight UTC.
+      description: Returns users ranked by weekly exp using DENSE_RANK, paginated at PAGE_SIZES.LEADERBOARD users per page. Includes the requesting user's rank and exp regardless of current page. Weekly exp resets every Monday at midnight UTC.
       security:
         - BearerAuth: []
       parameters:
@@ -537,7 +571,7 @@ paths:
           in: query
           required: false
           type: integer
-          description: Page number (default 1, PAGE_SIZE users per page, clamped to valid range)
+          description: Page number (default 1, PAGE_SIZES.LEADERBOARD users per page, clamped to valid range)
       responses:
         200:
           description: OK
@@ -554,7 +588,7 @@ paths:
         - Users
       summary: Fetch lifetime exp leaderboard.
       operationId: getLifetimeLeaderboard
-      description: Returns users ranked by lifetime exp using DENSE_RANK, paginated at PAGE_SIZE users per page. Includes the requesting user's rank and exp regardless of current page. Lifetime exp never resets.
+      description: Returns users ranked by lifetime exp using DENSE_RANK, paginated at PAGE_SIZES.LEADERBOARD users per page. Includes the requesting user's rank and exp regardless of current page. Lifetime exp never resets.
       security:
         - BearerAuth: []
       parameters:
@@ -562,7 +596,7 @@ paths:
           in: query
           required: false
           type: integer
-          description: Page number (default 1, PAGE_SIZE users per page, clamped to valid range)
+          description: Page number (default 1, PAGE_SIZES.LEADERBOARD users per page, clamped to valid range)
       responses:
         200:
           description: OK
@@ -579,7 +613,7 @@ paths:
         - Users
       summary: Fetch followed users weekly exp leaderboard.
       operationId: getFollowedWeeklyLeaderboard
-      description: Returns users that the requesting user follows, ranked by weekly exp using DENSE_RANK, paginated at PAGE_SIZE users per page. Includes the requesting user's rank and exp within the global pool regardless of current page. Returns an empty leaderboard if the requesting user follows nobody.
+      description: Returns users that the requesting user follows, ranked by weekly exp using DENSE_RANK, paginated at PAGE_SIZES.LEADERBOARD users per page. Includes the requesting user's rank and exp within the global pool regardless of current page. Returns an empty leaderboard if the requesting user follows nobody.
       security:
         - BearerAuth: []
       parameters:
@@ -587,7 +621,7 @@ paths:
           in: query
           required: false
           type: integer
-          description: Page number (default 1, PAGE_SIZE users per page, clamped to valid range)
+          description: Page number (default 1, PAGE_SIZES.LEADERBOARD users per page, clamped to valid range)
       responses:
         200:
           description: OK
@@ -604,7 +638,7 @@ paths:
         - Users
       summary: Fetch followed users lifetime exp leaderboard.
       operationId: getFollowedLifetimeLeaderboard
-      description: Returns users that the requesting user follows, ranked by lifetime exp using DENSE_RANK, paginated at PAGE_SIZE users per page. Includes the requesting user's rank and exp within the global pool regardless of current page. Returns an empty leaderboard if the requesting user follows nobody.
+      description: Returns users that the requesting user follows, ranked by lifetime exp using DENSE_RANK, paginated at PAGE_SIZES.LEADERBOARD users per page. Includes the requesting user's rank and exp within the global pool regardless of current page. Returns an empty leaderboard if the requesting user follows nobody.
       security:
         - BearerAuth: []
       parameters:
@@ -612,7 +646,7 @@ paths:
           in: query
           required: false
           type: integer
-          description: Page number (default 1, PAGE_SIZE users per page, clamped to valid range)
+          description: Page number (default 1, PAGE_SIZES.LEADERBOARD users per page, clamped to valid range)
       responses:
         200:
           description: OK
@@ -1566,6 +1600,48 @@ definitions:
         items:
           $ref: '#/definitions/StoreItem'
 
+  UserSearchResponse:
+    type: object
+    properties:
+      users:
+        type: array
+        items:
+          type: object
+          properties:
+            ID:
+              type: integer
+              example: 42
+            USERNAME:
+              type: string
+              example: "knightking"
+            FIRSTNAME:
+              type: string
+              example: "Arthur"
+              nullable: true
+            LASTNAME:
+              type: string
+              example: "Pendragon"
+              nullable: true
+      pagination:
+        type: object
+        properties:
+          page:
+            type: integer
+            example: 1
+            description: The actual page returned (clamped to valid range).
+          pageSize:
+            type: integer
+            example: 20
+            description: Number of results per page.
+          totalUsers:
+            type: integer
+            example: 3
+            description: Total number of matching users across all pages.
+          totalPages:
+            type: integer
+            example: 1
+            description: Total number of pages for this query.
+
   PurchasesResponse:
     type: object
     properties:
@@ -1679,7 +1755,7 @@ definitions:
       totalPages:
         type: integer
         example: 1
-        description: Total number of pages at PAGE_SIZE users per page.
+        description: Total number of pages at PAGE_SIZES.LEADERBOARD users per page.
       leaderboard:
         type: array
         items:
@@ -1702,7 +1778,7 @@ definitions:
               type: string
               example: "Octocat"
               nullable: true
-        description: "Page of users ranked by exp. Tied users share the same rank. PAGE_SIZE users per page."
+        description: "Page of users ranked by exp. Tied users share the same rank. PAGE_SIZES.LEADERBOARD users per page."
 
   GuildNameResponse:
     type: object

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -509,6 +509,103 @@ paths:
         500:
           description: Server Error
 
+  /users/{id}/stats-opt-in:
+    put:
+      tags:
+        - Users
+      summary: Update stats sharing opt-in.
+      operationId: updateStatsOptIn
+      description: |
+        Sets whether the user's response data is included in professor-facing aggregate analytics.
+        - Explicitly sets the value rather than toggling, so repeated calls with the same value don't change it.
+        - Can only be performed by the account owner.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the user.
+        - in: body
+          name: statsOptInItem
+          description: Desired opt-in state.
+          schema:
+            $ref: '#/definitions/StatsOptIn'
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/StatsOptInResponse'
+        400:
+          description: Bad Request - Invalid user ID or optIn is not a boolean
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Can only update own settings
+        404:
+          description: User Not Found
+        500:
+          description: Server Error
+
+  /stats/aggregate:
+    get:
+      tags:
+        - Stats
+      summary: Fetch aggregate stats across all opted-in users.
+      operationId: getAggregateStats
+      description: |
+        Returns median accuracy and median elapsed time across all responses from opted-in users.
+        - Also includes a per-subcategory breakdown of the same metrics.
+        - Median is used rather than mean to reduce skew from outliers such as users who left their computer mid-question.
+        - Returns nulls and an empty breakdown if no opted-in responses exist.
+      security:
+        - BearerAuth: []
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/AggregateStatsResponse'
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Professor or admin access only
+        500:
+          description: Server Error
+
+  /stats/aggregate/{questionId}:
+    get:
+      tags:
+        - Stats
+      summary: Fetch aggregate stats for a single question.
+      operationId: getAggregateStatsByQuestion
+      description: |
+        Returns median accuracy and median elapsed time for a single question, computed across all responses from opted-in users.
+        - Returns nulls if no opted-in responses exist for the question.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: questionId
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the question.
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/AggregateStatsByQuestionResponse'
+        400:
+          description: Bad Request - Invalid question ID
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Professor or admin access only
+        404:
+          description: Question Not Found
+        500:
+          description: Server Error
+
   /store:
     get:
       tags:
@@ -1507,6 +1604,10 @@ definitions:
         type: string
         example: "I/O"
         description: The subcategory/topic of the question.
+      elapsedTime:
+        type: integer
+        example: 45
+        description: Time in seconds from question display to submission. Optional, null if not provided.
   
   SubmitResponse:
     type: object
@@ -1786,6 +1887,82 @@ definitions:
       name:
         type: string
         example: "Blazing Dragons"
+
+  StatsOptIn:
+    type: object
+    required:
+      - optIn
+    properties:
+      optIn:
+        type: boolean
+        example: true
+        description: True to include this user's responses in aggregate stats, false to exclude.
+
+  StatsOptInResponse:
+    type: object
+    properties:
+      message:
+        type: string
+        example: "Stats sharing enabled"
+      optIn:
+        type: boolean
+        example: true
+
+  AggregateStatsResponse:
+    type: object
+    properties:
+      medianAccuracy:
+        type: number
+        example: 0.75
+        nullable: true
+        description: Median normalized score (0-1) across all opted-in responses. Null if no data.
+      medianElapsedTime:
+        type: number
+        example: 60
+        nullable: true
+        description: Median elapsed time in seconds across opted-in responses with non-null times. Null if no data.
+      responseCount:
+        type: integer
+        example: 120
+        description: Total number of opted-in responses included in the calculation.
+      subcategoryBreakdown:
+        type: object
+        description: Per-subcategory aggregate stats. Keys are Question.SUBCATEGORY strings.
+        additionalProperties:
+          type: object
+          properties:
+            medianAccuracy:
+              type: number
+              example: 0.6
+              nullable: true
+            medianElapsedTime:
+              type: number
+              example: 45
+              nullable: true
+            responseCount:
+              type: integer
+              example: 30
+
+  AggregateStatsByQuestionResponse:
+    type: object
+    properties:
+      questionId:
+        type: integer
+        example: 42
+      medianAccuracy:
+        type: number
+        example: 0.5
+        nullable: true
+        description: Median normalized score (0-1) across opted-in responses for this question. Null if no data.
+      medianElapsedTime:
+        type: number
+        example: 60
+        nullable: true
+        description: Median elapsed time in seconds across opted-in responses for this question. Null if no data.
+      responseCount:
+        type: integer
+        example: 3
+        description: Number of opted-in responses for this question.
 
 host: www.knightwise.dev
 basePath: /api

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -423,6 +423,58 @@ paths:
         500:
           description: Server Error
 
+  /users/{id}/follow:
+    post:
+      tags:
+        - Users
+      summary: Follow a user.
+      operationId: followUser
+      description: Follows the user with the given ID. Following is immediate and one-way, no acceptance required from the followee. A user cannot follow themselves or follow the same user twice.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the user to follow.
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Invalid user ID, user already followed, or attempting to follow yourself
+        401:
+          description: Unauthorized
+        404:
+          description: User Not Found
+        500:
+          description: Server Error
+    delete:
+      tags:
+        - Users
+      summary: Unfollow a user.
+      operationId: unfollowUser
+      description: Unfollows the user with the given ID. One-way, does not affect whether the followee follows the requesting user.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: The unique ID of the user to unfollow.
+      responses:
+        200:
+          description: OK
+        400:
+          description: Bad Request - Invalid user ID or user not currently followed
+        401:
+          description: Unauthorized
+        404:
+          description: User Not Found
+        500:
+          description: Server Error
+
   /store:
     get:
       tags:

--- a/backend/utils/analyticsModel.js
+++ b/backend/utils/analyticsModel.js
@@ -20,7 +20,8 @@ const {
         WEIGHT_TYPE,
         SUBCATEGORY_DIFFICULTY,
         TYPE_DIFFICULTY,
-        MAX_ELAPSED_TIME_SECONDS,
+        MAX_ELAPSED_TIME_BY_TYPE,
+        DEFAULT_ELAPSED_TIME_CEILING,
         DEFAULT_DIFFICULTY,
       } = require('../../shared/analyticsConfig');
 const { normalizeDBString } = require('../utils/validationUtils');
@@ -35,7 +36,8 @@ const { normalizeDBString } = require('../utils/validationUtils');
  * 
  * Component breakdown:
  *   - Accuracy:    normalizedScore (points_earned / points_possible)
- *   - Time:        1 - (elapsedTime / MAX_ELAPSED_TIME_SECONDS), clamped to [0, 1]
+ *   - Time:        1 - (elapsedTime / timeCeiling), clamped to [0, 1]
+ *                  timeCeiling depends on question type, see analyticsConfig
  *                  Null elapsed time uses neutral score of 0.5
  *   - Subcategory: difficulty scalar from analyticsConfig
  *   - Type:        difficulty scalar from analyticsConfig
@@ -52,9 +54,10 @@ const computePerformanceMetric = ({ normalizedScore, elapsedTime, subcategory, t
   const accuracyScore = Math.max(0, Math.min(1, normalizedScore));
 
   // Time component: clamp to [0,1], use neutral 0.5 if null
+  const timeCeiling = MAX_ELAPSED_TIME_BY_TYPE[normalizeDBString(type ?? '')] ?? DEFAULT_ELAPSED_TIME_CEILING;
   const timeScore = (elapsedTime == null)
     ? 0.5
-    : 1 - Math.min(1, elapsedTime / MAX_ELAPSED_TIME_SECONDS);
+    : 1 - Math.min(1, elapsedTime / timeCeiling);
 
   // Subcategory and type difficulty scalars
   const subcategoryScore = SUBCATEGORY_DIFFICULTY[normalizeDBString(subcategory ?? '')] ?? DEFAULT_DIFFICULTY;

--- a/backend/utils/analyticsModel.js
+++ b/backend/utils/analyticsModel.js
@@ -1,0 +1,105 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          analyticsModel.js
+//  Description:   KnightWise analytics engine.
+//                 Computes a weighted performance metric
+//                 (0.0 - 1.0) per response.
+//
+//  Dependencies:  analyticsConfig
+//
+////////////////////////////////////////////////////////////////
+
+const {
+  WEIGHT_ACCURACY,
+  WEIGHT_TIME,
+  WEIGHT_SUBCATEGORY,
+  WEIGHT_TYPE,
+  SUBCATEGORY_DIFFICULTY,
+  TYPE_DIFFICULTY,
+  MAX_ELAPSED_TIME_SECONDS,
+  DEFAULT_DIFFICULTY,
+} = require('../../shared/analyticsConfig');
+
+/**
+ * Computes a weighted performance metric for a single response
+ * Result is a value from 0.0 to 1.0, higher is better
+ *
+ * NOTE: Point value is intentionally excluded here. It is applied at aggregation
+ *       time w/ computeWeightedTopicMetric so that higher-point questions
+ *       influence topic ranking more without breaking the 0-1 per-response bound.
+ * 
+ * Component breakdown:
+ *   - Accuracy:    normalizedScore (points_earned / points_possible)
+ *   - Time:        1 - (elapsedTime / MAX_ELAPSED_TIME_SECONDS), clamped to [0, 1]
+ *                  Null elapsed time uses neutral score of 0.5
+ *   - Subcategory: difficulty scalar from analyticsConfig
+ *   - Type:        difficulty scalar from analyticsConfig
+ *
+ * @param {Object}      response                  - Question response to compute metric for
+ * @param {number}      response.normalizedScore  - Points earned / points possible (0-1)
+ * @param {number|null} response.elapsedTime      - Seconds taken to answer, or null
+ * @param {string}      response.subcategory      - Question.SUBCATEGORY string
+ * @param {string}      response.type             - Question.TYPE string
+ * @returns {number} Performance metric, 0.0 to 1.0
+ */
+const computePerformanceMetric = ({ normalizedScore, elapsedTime, subcategory, type }) => {
+  // Accuracy component: most heavily weighted
+  const accuracyScore = Math.max(0, Math.min(1, normalizedScore));
+
+  // Time component: clamp to [0,1], use neutral 0.5 if null
+  const timeScore = (elapsedTime == null)
+    ? 0.5
+    : 1 - Math.min(1, elapsedTime / MAX_ELAPSED_TIME_SECONDS);
+
+  // Subcategory and type difficulty scalars
+  const subcategoryScore = SUBCATEGORY_DIFFICULTY[subcategory] ?? DEFAULT_DIFFICULTY;
+  const typeScore        = TYPE_DIFFICULTY[type]               ?? DEFAULT_DIFFICULTY;
+
+  return (
+    WEIGHT_ACCURACY    * accuracyScore    +
+    WEIGHT_TIME        * timeScore        +
+    WEIGHT_SUBCATEGORY * subcategoryScore +
+    WEIGHT_TYPE        * typeScore
+  );
+};
+
+/**
+ * Computes a point-weighted average metric for a topic
+ * Higher point value responses contribute more to the topic score,
+ * naturally making higher-point questions more influential in ranking.
+ *
+ * @param {number[]} metrics     - Per-response performance metrics (0-1)
+ * @param {number[]} pointValues - Corresponding pointsPossible for each response
+ * @returns {number} Weighted average metric, 0.0 to 1.0, or 0 if empty
+ */
+const computeWeightedTopicMetric = (metrics, pointValues) => {
+  if (!metrics || metrics.length === 0) return 0;
+  const totalWeight = pointValues.reduce((sum, p) => sum + p, 0);
+  const weightedSum = metrics.reduce((sum, m, i) => sum + m * pointValues[i], 0);
+  return totalWeight > 0 ? weightedSum / totalWeight : 0;
+};
+
+/**
+ * Computes a median value from an array of numbers.
+ * Returns null for empty arrays.
+ *
+ * @param {number[]} values - Data set
+ * @returns {number|null}   - Median
+ */
+const computeMedian = (values) => {
+  if (!values || values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+
+module.exports = {
+  computePerformanceMetric,
+  computeWeightedTopicMetric,
+  computeMedian,
+};

--- a/backend/utils/analyticsModel.js
+++ b/backend/utils/analyticsModel.js
@@ -9,19 +9,21 @@
 //                 (0.0 - 1.0) per response.
 //
 //  Dependencies:  analyticsConfig
+//                 validationUtils
 //
 ////////////////////////////////////////////////////////////////
 
 const {
-  WEIGHT_ACCURACY,
-  WEIGHT_TIME,
-  WEIGHT_SUBCATEGORY,
-  WEIGHT_TYPE,
-  SUBCATEGORY_DIFFICULTY,
-  TYPE_DIFFICULTY,
-  MAX_ELAPSED_TIME_SECONDS,
-  DEFAULT_DIFFICULTY,
-} = require('../../shared/analyticsConfig');
+        WEIGHT_ACCURACY,
+        WEIGHT_TIME,
+        WEIGHT_SUBCATEGORY,
+        WEIGHT_TYPE,
+        SUBCATEGORY_DIFFICULTY,
+        TYPE_DIFFICULTY,
+        MAX_ELAPSED_TIME_SECONDS,
+        DEFAULT_DIFFICULTY,
+      } = require('../../shared/analyticsConfig');
+const { normalizeDBString } = require('../utils/validationUtils');
 
 /**
  * Computes a weighted performance metric for a single response
@@ -55,8 +57,8 @@ const computePerformanceMetric = ({ normalizedScore, elapsedTime, subcategory, t
     : 1 - Math.min(1, elapsedTime / MAX_ELAPSED_TIME_SECONDS);
 
   // Subcategory and type difficulty scalars
-  const subcategoryScore = SUBCATEGORY_DIFFICULTY[subcategory] ?? DEFAULT_DIFFICULTY;
-  const typeScore        = TYPE_DIFFICULTY[type]               ?? DEFAULT_DIFFICULTY;
+  const subcategoryScore = SUBCATEGORY_DIFFICULTY[normalizeDBString(subcategory ?? '')] ?? DEFAULT_DIFFICULTY;
+  const typeScore        = TYPE_DIFFICULTY[normalizeDBString(type ?? '')]               ?? DEFAULT_DIFFICULTY;
 
   return (
     WEIGHT_ACCURACY    * accuracyScore    +

--- a/backend/utils/currencyUtils.js
+++ b/backend/utils/currencyUtils.js
@@ -8,10 +8,12 @@
 //                 user currency (coins and exp)
 //
 //  Dependencies:  currencyConfig
+//                 guildConfig
 //
 ////////////////////////////////////////////////////////////////
 
 const { EXP_PER_POINT, COINS_PER_POINT, DAILY_EXP_CAP } = require('../../shared/currencyConfig');
+const { GUILD_EXP_CONTRIBUTION_RATIO } = require('../../shared/guildConfig')
 
 /**
  * Awards exp and coins to a user based on points earned
@@ -51,6 +53,42 @@ const awardCurrency = async (db, userId, pointsEarned) => {
   }
 };
 
+/**
+ * Awards ambient exp to a user's guild if they are a member of one
+ * Contributes GUILD_EXP_CONTRIBUTION_RATIO of earned exp to the guild's
+ * DAILY_EXP, WEEKLY_EXP, and LIFETIME_EXP banks
+ * Does NOT decrement from the user's own exp
+ * No-ops if the user is not in a guild
+ *
+ * @param {Object} db           - Database connection pool
+ * @param {number} userId       - ID of the user who earned exp
+ * @param {number} pointsEarned - Points earned from the submission
+ */
+const awardGuildExp = async (db, userId, pointsEarned) => {
+  // Check if user is in a guild
+  const [[membership]] = await db.query(
+    'SELECT GUILD_ID FROM GuildMember WHERE USER_ID = ?',
+    [userId]
+  );
+  if (!membership) return; // No-op
+
+  const expEarned    = pointsEarned * EXP_PER_POINT;
+  const guildExpGain = expEarned * GUILD_EXP_CONTRIBUTION_RATIO;
+
+  // If user got no exp from their question
+  if (guildExpGain <= 0) return;
+
+  await db.query(
+    `UPDATE Guild SET
+      DAILY_EXP    = DAILY_EXP    + ?,
+      WEEKLY_EXP   = WEEKLY_EXP   + ?,
+      LIFETIME_EXP = LIFETIME_EXP + ?
+     WHERE ID = ?`,
+    [guildExpGain, guildExpGain, guildExpGain, membership.GUILD_ID]
+  );
+};
+
 module.exports = {
   awardCurrency,
+  awardGuildExp,
 }

--- a/backend/utils/validationUtils.js
+++ b/backend/utils/validationUtils.js
@@ -34,7 +34,11 @@ const { AppError } = require('../middleware/errorHandler');
  * @returns {string} Normalized string
  */
 const normalizeDBString = (str) => {
-  return str.replace(/\r\n|\r|\n/g, ' ').trim().replace('Input/Output', 'InputOutput');
+  return str
+    .replace(/\r\n|\r|\n/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace('Input/Output', 'InputOutput');
 }
 
 /**

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -518,7 +518,7 @@ const Dashboard: React.FC = () => {
                   <div key={topic} className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 bg-gray-50">
                     <div>
                       <p className="font-semibold text-gray-900">{formatTopicLabel(topic)}</p>
-                      <p className="text-xs text-gray-500">Mastery: {Math.round(score)}%</p>
+                      <p className="text-xs text-gray-500">Mastery: {Math.round(score * 100)}%</p>
                     </div>
                     <button
                       type="button"

--- a/frontend/src/components/Graph.tsx
+++ b/frontend/src/components/Graph.tsx
@@ -91,8 +91,8 @@ const Graph: React.FC = () => {
         data: allTopics.map(topic => {
           // Set the mastery level (percentage) for each topic
           const topicData = progressData[topic];
-          if (topicData !== undefined && topicData.percentage !== undefined) {
-            return parseFloat(topicData.percentage.toString());
+          if (topicData !== undefined && topicData.metric !== undefined) {
+            return parseFloat((topicData.metric * 100).toFixed(1));
           }
           return 0;  // Set to 0 if no data is available for this topic
         }),

--- a/frontend/src/components/ProgressMessage.tsx
+++ b/frontend/src/components/ProgressMessage.tsx
@@ -52,7 +52,7 @@ const ProgressMessage: React.FC<ProgressMessageProps> = ({ history, mastery, str
     .filter(([, level]) => typeof level === "number")
     .sort((a, b) => (a[1] as number) - (b[1] as number));
 
-  const weakestTopic = (attemptedTopics.length > 0 && attemptedTopics[0][1] < 100)
+  const weakestTopic = (attemptedTopics.length > 0 && attemptedTopics[0][1] < 1.0)
     ? attemptedTopics[0][0]
     : null;
 

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -182,5 +182,6 @@ export interface ProgressData
 
 export interface TopicProgress
 {
-  percentage: number;
+  metric:        number;
+  responseCount: number;
 }

--- a/shared/analyticsConfig.js
+++ b/shared/analyticsConfig.js
@@ -12,8 +12,6 @@
 //                 To make this .ts, the backend Jest would need to 
 //                 be configured with ts-jest or similar.
 //
-//                 TODO: USE normalizeDBString() IN THIS FILE ONCE SCRUM-204 GOES IN
-//
 ////////////////////////////////////////////////////////////////
 
 // Note that all the WEIGHT values below add up to 1.0.

--- a/shared/analyticsConfig.js
+++ b/shared/analyticsConfig.js
@@ -71,10 +71,26 @@ const TYPE_DIFFICULTY = Object.freeze({
   'Programming':           1.0,
 });
 
-// Elapsed time normalization ceiling in seconds
-// Responses at or above this value get the worst time score
-// Handles users who left mid-question
-const MAX_ELAPSED_TIME_SECONDS = 300;
+// Time ceilings (seconds), dependent on question type
+// If a user takes this many seconds or longer
+// to answer a question of this type, they
+// will receive the lowest time score of the metric.
+// Implicitly weighs time metric different depending
+// on question type; 10 minutes on a programming question
+// is weighed far more favorably than 10 minutes
+// on a multiple choice question.
+const MAX_ELAPSED_TIME_BY_TYPE = Object.freeze({
+  'Multiple Choice':       120,   // 2 minutes
+  'Fill in the Blanks':    180,   // 3 minutes
+  'Select All That Apply': 180,   // 3 minutes
+  'Ranked Choice':         240,   // 4 minutes 
+  'Drag and Drop':         300,   // 5 minutes
+  'Programming':           1500,  // 25 minutes
+});
+
+// Fallback time scalar for unknown types
+// (Ideally we never use this but database string inconsistencies may cause this)
+const DEFAULT_ELAPSED_TIME_CEILING = 300;
 
 // Fallback difficulty scalar for unknown subcategories/types
 // (Ideally we never use this but database string inconsistencies may cause this)
@@ -87,6 +103,7 @@ module.exports = {
   WEIGHT_TYPE,
   SUBCATEGORY_DIFFICULTY,
   TYPE_DIFFICULTY,
-  MAX_ELAPSED_TIME_SECONDS,
+  MAX_ELAPSED_TIME_BY_TYPE,
+  DEFAULT_ELAPSED_TIME_CEILING,
   DEFAULT_DIFFICULTY,
 };

--- a/shared/analyticsConfig.js
+++ b/shared/analyticsConfig.js
@@ -1,0 +1,94 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          analyticsConfig.js
+//  Description:   Shared config for the KnightWise analytics
+//                 engine. Weights are tunable.
+//
+//  Note:          This file is intentionally .js rather than .ts,
+//                 for CommonJS compatibility with our backend Jest.
+//                 To make this .ts, the backend Jest would need to 
+//                 be configured with ts-jest or similar.
+//
+//                 TODO: USE normalizeDBString() IN THIS FILE ONCE SCRUM-204 GOES IN
+//
+////////////////////////////////////////////////////////////////
+
+// Note that all the WEIGHT values below add up to 1.0.
+
+// Weight for normalized score (accuracy). Most important factor.
+const WEIGHT_ACCURACY = 0.6;
+
+// Weight for elapsed time. Faster answers score higher.
+// But note how this is weighed considerably less
+// than accuracy, so users can't abuse this by spamming submits.
+const WEIGHT_TIME = 0.15;
+
+// Weight for subcategory difficulty. More advanced topics count more.
+const WEIGHT_SUBCATEGORY = 0.15;
+
+// Weight for question type difficulty.
+const WEIGHT_TYPE = 0.1;
+
+// Subcategory difficulty scalars (0.0 - 1.0)
+// Currently strings match Question.SUBCATEGORY
+// If/when subcategories become enums, update keys to match
+const SUBCATEGORY_DIFFICULTY = Object.freeze({
+  // Introductory Programming
+  'Variables':          0.3,
+  'InputOutput':        0.3,
+  'Branching':          0.3,
+  'Loops':              0.3,
+  // Simple Data Structures
+  'Arrays':             0.5,
+  'Linked Lists':       0.5,
+  'Strings':            0.5,
+  // Object Oriented Programming
+  'Methods':            0.6,
+  'Classes':            0.6,
+  // Intermediate Data Structures
+  'Trees':              0.7,
+  'Stacks':             0.7,
+  // Complex Data Structures
+  'Heaps':              0.8,
+  'Tries':              0.8,
+  // Intermediate Programming
+  'Recursion':          0.9,
+  'Sorting':            0.9,
+  'Algorithm Analysis': 0.9,
+  'Dynamic Memory':     0.9,
+  'Bitwise Operators':  0.9,
+});
+
+// Question type difficulty scalars (0.0 - 1.0)
+// Strings must exactly match Question.TYPE
+const TYPE_DIFFICULTY = Object.freeze({
+  'Multiple Choice':       0.2,
+  'Fill in the Blanks':    0.4,
+  'Select All That Apply': 0.5,
+  'Ranked Choice':         0.6,
+  'Drag and Drop':         0.7,
+  'Programming':           1.0,
+});
+
+// Elapsed time normalization ceiling in seconds
+// Responses at or above this value get the worst time score
+// Handles users who left mid-question
+const MAX_ELAPSED_TIME_SECONDS = 300;
+
+// Fallback difficulty scalar for unknown subcategories/types
+// (Ideally we never use this but database string inconsistencies may cause this)
+const DEFAULT_DIFFICULTY = 0.5;
+
+module.exports = {
+  WEIGHT_ACCURACY,
+  WEIGHT_TIME,
+  WEIGHT_SUBCATEGORY,
+  WEIGHT_TYPE,
+  SUBCATEGORY_DIFFICULTY,
+  TYPE_DIFFICULTY,
+  MAX_ELAPSED_TIME_SECONDS,
+  DEFAULT_DIFFICULTY,
+};

--- a/shared/guildConfig.js
+++ b/shared/guildConfig.js
@@ -1,0 +1,27 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          guildConfig.js
+//  Description:   Shared config for guild constants.
+//
+//  Note:          This file is intentionally .js rather than .ts,
+//                 for CommonJS compatibility with our backend Jest.
+//                 To make this .ts, the backend Jest would need to 
+//                 be configured with ts-jest or similar.
+//
+////////////////////////////////////////////////////////////////
+
+// Maximum number of members a guild can have (including owner)
+const MAX_GUILD_SIZE = 20;
+
+// Ratio of exp earned by a member that is also contributed to their guild's exp banks
+// Does not decrement from the member's own exp, just adds to the guild
+// Example: 0.1 means 10% of earned exp is also added to the guild
+const GUILD_EXP_CONTRIBUTION_RATIO = 0.1;
+
+module.exports = {
+  MAX_GUILD_SIZE,
+  GUILD_EXP_CONTRIBUTION_RATIO,
+};


### PR DESCRIPTION
This PR addresses [SCRUM-178: API - Guilds, Updated Statistics](https://knightwise.atlassian.net/browse/SCRUM-178) and its subtasks:
- [SCRUM-184: Automatic name generation for guilds](https://knightwise.atlassian.net/browse/SCRUM-184)

- This PR adds backend support for guilds (including the guild leaderboard), following, the follower leaderboard, the KnightWise analytics engine (AKA enhanced statistics collection), and aggregate statistics viewing for admins/professors with user opt-in.
- For the sake of brevity, not all of the endpoints or extensive edge cases will be listed in this PR. Please see the updated `swagger.yaml` documentation, test files, and end-to-end test screenshots further down for information on specific implementation details.

# Guilds
- Added backend support for guild name generation, starting with 23 adjectives and 27 plural nouns. 
  - This means KnightWise can currently support **621** guilds, each with a unique name.
- Added guild operations for:
  - Creating and deleting guilds.
  - Requesting to join a guild.
  - Opening and closing a guild (open means users can request to join, not open means they can't).
  - Being invited to a guild.
  - Actively contributing coins to a guild.
  - Passively contributing exp to a guild.
  - Unlocking and equipping/unequipping guild store items.
  - Promoting and demoting with 3 roles: Owner, Officer, Member.
  - Kicking users from and leaving guilds.
  - Users viewing their guild invites and guilds (Officer or above) viewing incoming requests to join.
- Added weekly and lifetime guild leaderboard.

# Following, Follower Leaderboard, User Search
- Added backend support for:
  - Following and unfollowing users.
  - Follower leaderboard which shows how the user ranks against the users they follow.
  - Searching for users by username, which will be useful for following.

# Analytics Engine and Aggregate Statistics Viewing
- Added backend support for:
  - The KnightWise analytics engine, which is a linear model that includes weighted scalars such as score, question type, and elapsed time.
  - Made a couple small changes to integrate this into existing frontend components like the dashboard, progress message, and radar chart.
  - Admin/professor aggregate statistics viewing across subcategories and for a single question.
  - User opt-in toggling, which decides whether their responses are put into the aggregate pool.

**End-to-End Test:**

- Below: Some examples of randomly-generated guild names.
<img width="1711" height="437" alt="image" src="https://github.com/user-attachments/assets/dae2e512-c378-4f1e-987e-cce2a7db92ac" />
<img width="1724" height="424" alt="image" src="https://github.com/user-attachments/assets/8f8ca8c0-2160-42b0-97fe-2654159f99bb" />
<img width="1714" height="423" alt="image" src="https://github.com/user-attachments/assets/e729d15b-0bf7-4e79-a8b1-c39238fed86d" />

- Below: If guild word bank is unavailable (either the adjective list or plural noun list is empty).
<img width="1715" height="436" alt="image" src="https://github.com/user-attachments/assets/5a28d823-4687-4ad1-b94a-bd420e8ef924" />

- Below: If somehow every unique name combination belongs to a guild and there are none left.
<img width="1715" height="411" alt="image" src="https://github.com/user-attachments/assets/583d30f9-f270-487a-ada4-4d58686b5c24" />

- Below: All new tests passing.
<img width="835" height="350" alt="image" src="https://github.com/user-attachments/assets/e7319290-68d6-4430-833e-4a338fbb64aa" />

- Below: Two users log in. User 1 and user 78.
<img width="1721" height="725" alt="image" src="https://github.com/user-attachments/assets/3312bc7d-08a5-41a9-b9c4-319ef035e32d" />
<img width="1708" height="692" alt="image" src="https://github.com/user-attachments/assets/8ea00f48-43b6-41d0-85a2-a23aa4ed68c7" />

- Below: User search.
<img width="1718" height="957" alt="image" src="https://github.com/user-attachments/assets/ce584246-448a-4f1d-993d-afa54fed83f6" />
<img width="1711" height="559" alt="image" src="https://github.com/user-attachments/assets/05ce5cc5-ba92-4f7c-b4df-7b5e2dbe3d1a" />

- Below: Both opt-in for statistics sharing.
<img width="1710" height="605" alt="image" src="https://github.com/user-attachments/assets/15866cbc-701b-4911-b68f-1e7b71d322b5" />
<img width="1724" height="681" alt="image" src="https://github.com/user-attachments/assets/82fd023a-c122-40d1-9a9a-51df2da23697" />

- Below: Can't opt-in for another user that isn't you or invalid IDs.
<img width="1720" height="589" alt="image" src="https://github.com/user-attachments/assets/9de2919d-8582-481e-bdad-6be031ef448b" />
<img width="1727" height="595" alt="image" src="https://github.com/user-attachments/assets/6fb6b1ad-83ae-4a9a-9149-2f6fc4238aba" />
<img width="1720" height="588" alt="image" src="https://github.com/user-attachments/assets/7607e52e-b490-4a17-8719-374a6fbd6c59" />

- Below: New elapsedTime field.
<img width="1712" height="828" alt="image" src="https://github.com/user-attachments/assets/2e150558-94e8-4967-9710-ce601802a354" />
<img width="1707" height="818" alt="image" src="https://github.com/user-attachments/assets/90fd368f-7c20-46ff-8151-e38ac82eca6d" />

- Below: Admin/prof aggregate stats.
<img width="1725" height="948" alt="image" src="https://github.com/user-attachments/assets/9cb0594a-21ee-44f0-aec5-9cd1a13d776d" />
<img width="624" height="562" alt="image" src="https://github.com/user-attachments/assets/2213b92d-075d-464b-97be-9726c6c25f84" />
<img width="1715" height="480" alt="image" src="https://github.com/user-attachments/assets/67d24efa-915f-4895-a46b-8946a5599701" />

- Below: User following
<img width="1744" height="599" alt="image" src="https://github.com/user-attachments/assets/bb12914c-a8de-481e-9318-cb7dc323e9ff" />
<img width="1713" height="550" alt="image" src="https://github.com/user-attachments/assets/59098631-9fcb-4fd6-b7ae-90aefe0558d3" />
<img width="1725" height="510" alt="image" src="https://github.com/user-attachments/assets/41a4514b-5a8d-4f6a-ae59-b9e5d4094967" />
<img width="1710" height="490" alt="image" src="https://github.com/user-attachments/assets/07c81aa6-a355-48fa-a74b-fba19983d793" />

- Below: Follower leaderboard.
<img width="1699" height="955" alt="image" src="https://github.com/user-attachments/assets/964a0b35-d97b-4a6d-939e-21231e695bc1" />
<img width="1722" height="951" alt="image" src="https://github.com/user-attachments/assets/785c86ed-7ab2-4251-bafc-20a650901edc" />

- Below: Create a guild.
- Note: Since taking this screenshot I also added members and unlocked items to the GET guild response. See this in later screenshots.
- Established is deliberately UTC for database consistency, if frontend wants to display that it has to convert to local time zone.
<img width="1713" height="604" alt="image" src="https://github.com/user-attachments/assets/8f044265-8c8e-423c-9b51-0211d121e575" />
<img width="547" height="108" alt="image" src="https://github.com/user-attachments/assets/626ccd84-2fa3-489b-910b-68302b9464d9" />
<img width="1716" height="714" alt="image" src="https://github.com/user-attachments/assets/d296d329-0a5c-4089-b8d0-a900030760fb" />

- Below: Invite user 78 to guild. 78 can see invite and accept.
<img width="1716" height="580" alt="image" src="https://github.com/user-attachments/assets/b5e2eb72-bd06-4f73-b661-31ab43dee154" />
<img width="1711" height="567" alt="image" src="https://github.com/user-attachments/assets/f4416013-1e4d-425c-bca3-332564b04333" />
<img width="1732" height="595" alt="image" src="https://github.com/user-attachments/assets/8be601fa-07a9-420f-b82e-c2a13c25ad11" />
<img width="1698" height="961" alt="image" src="https://github.com/user-attachments/assets/a93151ae-d865-4fed-b789-2bca80007af3" />

- Below: Owner promotes user 78 to Officer.
<img width="1712" height="640" alt="image" src="https://github.com/user-attachments/assets/e266e4bd-ee7b-4018-a619-6e0e9606d599" />
<img width="1697" height="930" alt="image" src="https://github.com/user-attachments/assets/9d5e8995-a655-43a5-bb8d-bcab4fcd7a4c" />

- Below: Check incoming requests to join guild.
<img width="1721" height="416" alt="image" src="https://github.com/user-attachments/assets/270626ed-c288-465a-9f68-412e9c0520ee" />

- Below: Contribute coins.
<img width="1734" height="635" alt="image" src="https://github.com/user-attachments/assets/b536a87b-5504-423e-8548-23b21db0de3c" />

- Below: Member 78 tries to demote the owner. Obviously can't.
<img width="1719" height="580" alt="image" src="https://github.com/user-attachments/assets/f9be18fd-3bc3-46c0-bd9f-e991790fcf1f" />

- Below: Owner gets mad and demotes user 78 back to Member.
<img width="1702" height="576" alt="image" src="https://github.com/user-attachments/assets/8a6374a8-9dba-4cd0-9b93-3dd066d8f898" />
<img width="1692" height="919" alt="image" src="https://github.com/user-attachments/assets/22c41469-f1ce-4359-a112-096d59f62fbb" />

- Below: User 78 leaves out of frustration.
<img width="1704" height="398" alt="image" src="https://github.com/user-attachments/assets/4033b80a-acce-492f-8f35-26b5736a55f3" />
<img width="1707" height="951" alt="image" src="https://github.com/user-attachments/assets/0b587f2b-cdc3-4f29-8721-8ea647794099" />

- Below: Owner tries to go after him but can't leave because he's the Owner.
<img width="1710" height="426" alt="image" src="https://github.com/user-attachments/assets/d8f653e8-cc7e-4092-82da-07e4ce010de8" />

- Below: Owner (or Officer) can close guild.
<img width="1724" height="605" alt="image" src="https://github.com/user-attachments/assets/f60fd0a3-fcca-43bf-979c-b9f877531673" />

- Below: User 78 can't request to join back.
<img width="1715" height="434" alt="image" src="https://github.com/user-attachments/assets/abacd068-5302-4bfe-9cc5-465f1e4ef2e7" />

- Below: Owner re-opens guild, now user 78 can request to join.
<img width="1706" height="591" alt="image" src="https://github.com/user-attachments/assets/163d9bf9-6b85-4ee2-bfe2-2deb5ba6f91c" />
<img width="1712" height="446" alt="image" src="https://github.com/user-attachments/assets/15187f99-63a8-4442-b47d-0acc7b58837d" />

- Below: Owner or officer can see the incoming request and accept/reject it.
<img width="1706" height="591" alt="image" src="https://github.com/user-attachments/assets/7141ed83-c819-418b-baa9-3b0961fcd094" />
<img width="1727" height="607" alt="image" src="https://github.com/user-attachments/assets/df28e606-5fd8-4f6c-9f96-72158fa7acb0" />
<img width="1714" height="941" alt="image" src="https://github.com/user-attachments/assets/7929c2bc-a23c-43e7-aab0-fa796314790c" />

- Below: Answering a question while in a guild will passively award exp to the guild at a configurable rate. Currently 10% I believe. So 20 exp from a question will also award 2 exp to the guild.
<img width="1717" height="831" alt="image" src="https://github.com/user-attachments/assets/d28b439d-d472-4dae-8024-d0f00228a54a" />
<img width="1694" height="940" alt="image" src="https://github.com/user-attachments/assets/b7236fb5-1077-45f3-bbc5-d42fedb38dda" />
<img width="1720" height="750" alt="image" src="https://github.com/user-attachments/assets/de3723a5-dee9-40c5-b0b4-290dfcedc330" />

- Below: Updated progress endpoints. A lot of the data is weird because I answered so many questions wrong on this account.
- But mastery is now a normalized value from 0-1.
- Since mastery is calculated based on the subcategory of responses, my account shows subcategories that don't exist anymore since my responses are old. This shouldn't happen for new users.
<img width="1736" height="904" alt="image" src="https://github.com/user-attachments/assets/0b9c3db3-e2d9-4ef5-9131-0df126f2772a" />
<img width="1700" height="937" alt="image" src="https://github.com/user-attachments/assets/f8c160e0-b584-4dbb-ab01-2641e39aa2e9" />
<img width="1706" height="947" alt="image" src="https://github.com/user-attachments/assets/26fcc50a-7a4a-48c9-9a56-aa1c912067b6" />
<img width="1705" height="962" alt="image" src="https://github.com/user-attachments/assets/a954e53d-35f8-451c-a69a-0943fd3f2f42" />
<img width="1699" height="944" alt="image" src="https://github.com/user-attachments/assets/464f1e9d-3c74-442d-b7ca-84f6f16b49a4" />

- Below: Enough statistics, you can delete guilds by the way.
- Since I took this screenshot I made it so that both create/delete webhooks show the ID and name of the guild.
<img width="1709" height="415" alt="image" src="https://github.com/user-attachments/assets/5422d227-f548-4b25-ae4c-462034396ef1" />
<img width="423" height="107" alt="image" src="https://github.com/user-attachments/assets/fe901a94-9d8a-47c9-9fc1-26fce82a563b" />

- Below: Guild item creation.
- Also I created an admin endpoint to delete store items. Be careful with this one due to cascading effects (it'll delete it from everyone who has it).
<img width="1715" height="732" alt="image" src="https://github.com/user-attachments/assets/f1f89050-4cef-422f-82af-e6ba4f2af91d" />
<img width="870" height="132" alt="image" src="https://github.com/user-attachments/assets/c91bb772-5267-40cc-ad2d-4ecd9583777b" />
<img width="1732" height="957" alt="image" src="https://github.com/user-attachments/assets/1c43497f-70b8-46e9-8af3-3b722dea8d9e" />

- Below: Users can't purchase guild items directly, they have to be unlocked when a guild reaches the coin threshold with enough contributions from members.
<img width="1705" height="447" alt="image" src="https://github.com/user-attachments/assets/91e43a76-8059-4138-ba54-2d067f2c691d" />
<img width="1713" height="933" alt="image" src="https://github.com/user-attachments/assets/2fdf9a37-e30f-488e-88ff-c773fd54c751" />

- Below: Contributed, now we unlocked it.
<img width="1734" height="815" alt="image" src="https://github.com/user-attachments/assets/3eb4cf92-6a46-4194-8b1f-bd753a799dd2" />
<img width="1739" height="953" alt="image" src="https://github.com/user-attachments/assets/5e35807a-9ba4-419f-8116-73ceaa48805a" />

- Below: Owner and Officers can equip/unequip.
- See how profile picture shows up in leaderboard.
<img width="1715" height="582" alt="image" src="https://github.com/user-attachments/assets/02bebd20-9421-45c6-bb28-8eac508b2c0d" />
<img width="1744" height="970" alt="image" src="https://github.com/user-attachments/assets/fe93f942-d687-4c5d-abad-b0c0be09decc" />
<img width="1722" height="758" alt="image" src="https://github.com/user-attachments/assets/502750c3-42d3-4172-b7b0-178685f671a4" />
<img width="1726" height="586" alt="image" src="https://github.com/user-attachments/assets/4b125814-c4bf-4492-93be-5149896d97bc" />
<img width="1728" height="945" alt="image" src="https://github.com/user-attachments/assets/471575b2-1962-43ed-abcc-da66810e0e77" />

- The `swagger.yaml` documentation was updated to reflect all API changes.
- Changes were tested locally.

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-178
- https://knightwise.atlassian.net/browse/SCRUM-182
- https://knightwise.atlassian.net/browse/SCRUM-183
- https://knightwise.atlassian.net/browse/SCRUM-184
- https://knightwise.atlassian.net/browse/SCRUM-185
- https://knightwise.atlassian.net/browse/SCRUM-186
- https://knightwise.atlassian.net/browse/SCRUM-207