### PR TITLE
SCRUM-219: Add IS_SHARING_STATS to GET /api/users/:id

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -165,7 +165,7 @@ const getUserInfo = asyncHandler(async (req, res) => {
   // Get user info (including user currency info), and equips
   const [[users], [equippedItems]] = await Promise.all([
     req.db.query( // Get user info w/ currency info from User table
-      'SELECT ID, USERNAME, FIRSTNAME, LASTNAME, LIFETIME_EXP, WEEKLY_EXP, DAILY_EXP, COINS FROM User WHERE ID = ?',
+      'SELECT ID, USERNAME, FIRSTNAME, LASTNAME, LIFETIME_EXP, WEEKLY_EXP, DAILY_EXP, COINS, IS_SHARING_STATS FROM User WHERE ID = ?',
       [userId]
     ),
     req.db.query( // Get equip info from StoreItem/Purchase tables
@@ -186,7 +186,10 @@ const getUserInfo = asyncHandler(async (req, res) => {
     .status(200)
     .json(
       {
-        user: users[0],
+        user: {
+          ...users[0],
+          IS_SHARING_STATS: Boolean(users[0].IS_SHARING_STATS), // TINYINT in database, convert to boolean for readability
+        },
         equippedItems
       }
     );

--- a/backend/routes/myProgress.js
+++ b/backend/routes/myProgress.js
@@ -215,6 +215,7 @@ router.get('/history', authMiddleware, asyncHandler(async (req, res) => {
       r.USER_ANSWER,
       r.POINTS_EARNED,
       r.POINTS_POSSIBLE,
+      r.ELAPSED_TIME,
       q.TYPE
      FROM Response r
      JOIN Question q ON r.PROBLEM_ID = q.ID
@@ -241,6 +242,7 @@ router.get('/history', authMiddleware, asyncHandler(async (req, res) => {
       userAnswer:     row.USER_ANSWER,
       pointsEarned:   row.POINTS_EARNED,
       pointsPossible: row.POINTS_POSSIBLE,
+      elapsedTime:    row.ELAPSED_TIME ?? null,
     })),
     totalEntries,
     currentPage: page,

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -2320,6 +2320,10 @@ definitions:
           COINS:
             type: number
             example: 450.0
+          IS_SHARING_STATS:
+            type: boolean
+            example: false
+            description: "True if user opted into sharing aggregate statistics, false otherwise."
       equippedItems:
         type: array
         items:

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -71,14 +71,15 @@ export interface LeaderboardResponse
 // User types
 export interface UserInfo
 {
-  ID:           number;
-  USERNAME:     string | null; // While these should never be null, technically
-  FIRSTNAME:    string | null; // they can be according to the schema.
-  LASTNAME:     string | null;
-  DAILY_EXP:    number;
-  LIFETIME_EXP: number;
-  WEEKLY_EXP:   number;
-  COINS:        number;
+  ID:               number;
+  USERNAME:         string | null; // While these should never be null, technically
+  FIRSTNAME:        string | null; // they can be according to the schema.
+  LASTNAME:         string | null;
+  DAILY_EXP:        number;
+  LIFETIME_EXP:     number;
+  WEEKLY_EXP:       number;
+  COINS:            number;
+  IS_SHARING_STATS: boolean; // a number in the database, converted to boolean by API
 }
 
 // GET /api/users/:id response

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -146,6 +146,7 @@ export interface HistoryEntry
   userAnswer:     string | null; // JSON with answer data
   pointsEarned:   number | null;
   pointsPossible: number | null;
+  elapsedTime:    number | null;
 }
 
 export interface HistoryResponse


### PR DESCRIPTION
This PR addresses [SCRUM-219: Add IS_SHARING_STATS to GET /api/users/:id](https://knightwise.atlassian.net/browse/SCRUM-219).

- This PR adds an **IS_SHARING_STATS** field to the response body of **GET** `/api/users/:id` so that the frontend can see whether a given user is opted-in to sharing statistics with the aggregate pool. Previously there was no way to fetch this info.

- This PR also adds elapsed time to the response body of **GET** `/api/progress/history` so the user's elapsed time on their submissions can be accessed outside of when it's recorded.

- Updated the models in `models.ts` and `swagger.yaml` to reflect the new fields.

- Below: All tests still pass, tests were unaffected.
<img width="804" height="337" alt="image" src="https://github.com/user-attachments/assets/cd4edb80-5210-4f36-9a6b-ca65890f07fb" />

- Below: New **IS_SHARING_STATS** field in the GET user response body.
<img width="1720" height="934" alt="image" src="https://github.com/user-attachments/assets/00c3812b-27bd-4cc9-8ba3-19e57b88edb9" />

- Below: Opting in using the dedicated endpoint changes the value of this field.
<img width="1724" height="663" alt="image" src="https://github.com/user-attachments/assets/50356db2-6e19-449c-915f-275a0e5da506" />
<img width="1715" height="939" alt="image" src="https://github.com/user-attachments/assets/bbd9d290-dc6d-4cb3-bda0-a0f6e3583824" />

- Below: So does opting out.
<img width="1711" height="693" alt="image" src="https://github.com/user-attachments/assets/211c8594-1063-4449-8321-fa37956c8f46" />
<img width="1706" height="937" alt="image" src="https://github.com/user-attachments/assets/5d47f83b-ef0c-4945-9664-7dc31c77405b" />

- Below: When a new user is created, they are opted out by default. This is because the field simply isn't set when a user is created (in `authRoutes.js`) and the database field is default 0.
<img width="470" height="130" alt="image" src="https://github.com/user-attachments/assets/b5c2a86c-7124-4c69-aff6-d18db001292e" />
<img width="1705" height="706" alt="image" src="https://github.com/user-attachments/assets/6bfee2ce-6977-48ec-9a26-c15e6b5ca3f4" />

- Below: The new elapsed time returned by the history endpoint.
<img width="1733" height="993" alt="image" src="https://github.com/user-attachments/assets/775c4eea-a750-4a18-9235-17cd26894ff7" />

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-219