### PR TITLE
SCRUM-221: Add Aggregate Question Fetching Endpoint

### DIFF
--- a/backend/__test__/problems.test.js
+++ b/backend/__test__/problems.test.js
@@ -1,0 +1,459 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          problems.test.js
+//  Description:   Integration tests for problem/question routes:
+//                 GET /api/problems/:id
+//                 GET /api/problems
+//
+//  Dependencies:  supertest
+//                 mysql2 connection pool (server.js)
+//                 testHelpers
+//                 paginationConfig
+//
+////////////////////////////////////////////////////////////////
+
+const request = require('supertest');
+const { app, pool } = require('../server');
+const {
+  verifyTestDatabase,
+  getAuthToken,
+  getProfAuthToken,
+  insertQuestion,
+  insertUser,
+} = require('./testHelpers');
+const { PAGE_SIZES } = require('../config/paginationConfig');
+
+let studentToken;
+let profToken;
+let adminToken;
+
+// Subcategory names used across tests
+const SUB_ARRAYS    = 'Arrays';
+const SUB_RECURSION = 'Recursion';
+const SUB_SORTING   = 'Sorting';
+
+// Helper to make an AnswerText
+const makeAnswer = (text, isCorrect = true) => ({
+  text,
+  isCorrect,
+  rank: 1,
+  placement: '',
+});
+
+beforeAll(async () => {
+  await verifyTestDatabase(pool);
+  await pool.query('DELETE FROM User');
+
+  studentToken = await getAuthToken();
+  profToken    = await getProfAuthToken();
+  adminToken   = process.env.ADMIN_KEY;
+
+  // Insert published questions spread across subcategories
+  // Two Arrays, one Recursion, one Sorting
+  await insertQuestion('Multiple Choice', [makeAnswer('A')], {
+    points: 1, isPublished: true, subcategory: SUB_ARRAYS,
+  });
+  await insertQuestion('Multiple Choice', [makeAnswer('B')], {
+    points: 1, isPublished: true, subcategory: SUB_ARRAYS,
+  });
+  await insertQuestion('Multiple Choice', [makeAnswer('C')], {
+    points: 1, isPublished: true, subcategory: SUB_RECURSION,
+  });
+  await insertQuestion('Multiple Choice', [makeAnswer('D')], {
+    points: 1, isPublished: true, subcategory: SUB_SORTING,
+  });
+
+  // One draft (should NEVER appear in results)
+  await insertQuestion('Multiple Choice', [makeAnswer('E')], {
+    points: 1, isPublished: false, subcategory: SUB_ARRAYS,
+  });
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM User');
+  try
+  {
+    await pool.end();
+  }
+  catch (err)
+  {
+    console.error('Error closing pool in problems.test.js:', err);
+  }
+});
+
+// Test fetching questions by ID
+describe('GET /api/problems/:id', () => {
+
+  let publishedQuestionId;
+  let draftQuestionId;
+
+  beforeAll(async () => {
+    publishedQuestionId = await insertQuestion('Multiple Choice', [makeAnswer('A')], {
+      points: 2, isPublished: true, subcategory: SUB_ARRAYS,
+    });
+
+    draftQuestionId = await insertQuestion('Multiple Choice', [makeAnswer('B')], {
+      points: 2, isPublished: false, subcategory: SUB_ARRAYS,
+    });
+  });
+
+  test('200 - returns published question with answers attached', async () => {
+    const res = await request(app)
+      .get(`/api/problems/${publishedQuestionId}`)
+      .set('Authorization', `Bearer ${studentToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('ID', publishedQuestionId);
+    expect(res.body).toHaveProperty('answers');
+    expect(Array.isArray(res.body.answers)).toBe(true);
+    expect(res.body.answers.length).toBeGreaterThan(0);
+  });
+
+  test('200 - student can access published question', async () => {
+    const res = await request(app)
+      .get(`/api/problems/${publishedQuestionId}`)
+      .set('Authorization', `Bearer ${studentToken}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('200 - professor can access published question', async () => {
+    const res = await request(app)
+      .get(`/api/problems/${publishedQuestionId}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('404 - draft question is not returned', async () => {
+    const res = await request(app)
+      .get(`/api/problems/${draftQuestionId}`)
+      .set('Authorization', `Bearer ${studentToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('404 - question does not exist', async () => {
+    const res = await request(app)
+      .get('/api/problems/999999')
+      .set('Authorization', `Bearer ${studentToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .get(`/api/problems/${publishedQuestionId}`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Test fetching all published questions
+// Access control (admins/professors only)
+describe('GET /api/problems - access control', () => {
+
+  test('200 - professor can access', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('200 - admin can access', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('403 - student cannot access', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${studentToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('401 - no auth token', async () => {
+    const res = await request(app)
+      .get('/api/problems');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// Validate JSON response shape
+describe('GET /api/problems - response shape', () => {
+
+  test('200 - shape has questions and pagination', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('questions');
+    expect(res.body).toHaveProperty('pagination');
+  });
+
+  test('200 - pagination shape is correct', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    const { pagination } = res.body;
+    expect(pagination).toHaveProperty('page');
+    expect(pagination).toHaveProperty('pageSize');
+    expect(pagination).toHaveProperty('totalQuestions');
+    expect(pagination).toHaveProperty('totalPages');
+  });
+
+  test('200 - questions is an object keyed by subcategory, not an array', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(typeof res.body.questions).toBe('object');
+    expect(Array.isArray(res.body.questions)).toBe(false);
+  });
+
+  test('200 - each subcategory value is an array of question objects with answers', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    for (const questions of Object.values(res.body.questions))
+    {
+      expect(Array.isArray(questions)).toBe(true);
+      for (const q of questions)
+      {
+        expect(q).toHaveProperty('ID');
+        expect(q).toHaveProperty('SUBCATEGORY');
+        expect(q).toHaveProperty('answers');
+        expect(Array.isArray(q.answers)).toBe(true);
+      }
+    }
+  });
+});
+
+// Verify it only fetches published questions
+describe('GET /api/problems - published filter', () => {
+
+  test('200 - draft question ID never appears in results', async () => {
+    // Insert a fresh draft and confirm its ID is absent from the response
+    const draftId = await insertQuestion('Multiple Choice', [makeAnswer('X')], {
+      points: 1, isPublished: false, subcategory: SUB_ARRAYS,
+    });
+
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    const returnedIds = Object.values(res.body.questions)
+      .flat()
+      .map(q => q.ID);
+
+    expect(returnedIds).not.toContain(draftId);
+
+    // Cleanup — draft has no owner so delete directly by ID
+    await pool.query('DELETE FROM Question WHERE ID = ?', [draftId]);
+  });
+});
+
+// Verify response shape subcategory breakdown
+describe('GET /api/problems - subcategory grouping', () => {
+
+  test('200 - questions are grouped under correct subcategory keys', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.questions).toHaveProperty(SUB_ARRAYS);
+    expect(res.body.questions).toHaveProperty(SUB_RECURSION);
+    expect(res.body.questions).toHaveProperty(SUB_SORTING);
+  });
+
+  test('200 - each question includes its answers', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    const arraysQuestions = res.body.questions[SUB_ARRAYS];
+    expect(Array.isArray(arraysQuestions)).toBe(true);
+    expect(arraysQuestions[0].answers.length).toBeGreaterThan(0);
+  });
+});
+
+// Verify optional subcategory filter query param
+describe('GET /api/problems?subcategory=...', () => {
+
+  test('200 - single subcategory filter returns only that subcategory', async () => {
+    const res = await request(app)
+      .get(`/api/problems?subcategory=${SUB_ARRAYS}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    const keys = Object.keys(res.body.questions);
+    expect(keys).toContain(SUB_ARRAYS);
+    expect(keys).not.toContain(SUB_RECURSION);
+    expect(keys).not.toContain(SUB_SORTING);
+  });
+
+  test('200 - totalQuestions reflects subcategory filter', async () => {
+    const res = await request(app)
+      .get(`/api/problems?subcategory=${SUB_ARRAYS}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.body.pagination.totalQuestions).toBeGreaterThanOrEqual(2);
+    expect(res.body.questions).toHaveProperty(SUB_ARRAYS);
+    expect(res.body.questions).not.toHaveProperty(SUB_RECURSION);
+    expect(res.body.questions).not.toHaveProperty(SUB_SORTING);
+  });
+
+  test('200 - comma-separated subcategories returns only those subcategories', async () => {
+    const res = await request(app)
+      .get(`/api/problems?subcategory=${SUB_ARRAYS},${SUB_RECURSION}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    const keys = Object.keys(res.body.questions);
+    expect(keys).toContain(SUB_ARRAYS);
+    expect(keys).toContain(SUB_RECURSION);
+    expect(keys).not.toContain(SUB_SORTING);
+  });
+
+  test('200 - subcategory filter is case-insensitive', async () => {
+    const res = await request(app)
+      .get(`/api/problems?subcategory=${SUB_ARRAYS.toLowerCase()}`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.questions).toHaveProperty(SUB_ARRAYS);
+  });
+
+  test('200 - returns empty questions object for nonexistent subcategory', async () => {
+    const res = await request(app)
+      .get('/api/problems?subcategory=NonexistentSubcategory')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.questions).toEqual({});
+    expect(res.body.pagination.totalQuestions).toBe(0);
+  });
+});
+
+// Verify optional "only questions I own" professor query param
+describe('GET /api/problems?mine=true', () => {
+
+  test('200 - mine=true returns only the requesting professor\'s questions', async () => {
+    // Insert a question under an owner ID that won't match the test professor
+    const otherProfId = await insertUser({
+      username:  'other_prof',
+      email:     'other_prof@test.com',
+      isProf:    true,
+      verified:  true,
+    });
+
+    await insertQuestion('Multiple Choice', [makeAnswer('Z')], {
+      points: 1, isPublished: true, subcategory: SUB_ARRAYS, ownerId: otherProfId,
+    });
+
+    const res = await request(app)
+      .get('/api/problems?mine=true')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+
+    // No returned question should belong to the other professor
+    for (const questions of Object.values(res.body.questions))
+    {
+      for (const q of questions)
+      {
+        expect(q.OWNER_ID).not.toBe(otherProfId);
+      }
+    }
+
+    // Cleanup
+    await pool.query('DELETE FROM Question WHERE OWNER_ID = ?', [otherProfId]);
+    await pool.query('DELETE FROM User WHERE ID = ?', [otherProfId]);
+  });
+
+  test('200 - mine=false returns same total as omitting the param', async () => {
+    const resOmitted = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    const resFalse = await request(app)
+      .get('/api/problems?mine=false')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(resOmitted.status).toBe(200);
+    expect(resFalse.status).toBe(200);
+    expect(resFalse.body.pagination.totalQuestions)
+      .toBe(resOmitted.body.pagination.totalQuestions);
+  });
+});
+
+// Verify pagination
+describe('GET /api/problems - pagination', () => {
+
+  test('200 - default page is 1', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.body.pagination.page).toBe(1);
+  });
+
+  test('200 - non-numeric page is clamped to 1', async () => {
+    const res = await request(app)
+      .get('/api/problems?page=abc')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.page).toBe(1);
+  });
+
+  test('200 - page 0 is clamped to 1', async () => {
+    const res = await request(app)
+      .get('/api/problems?page=0')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.page).toBe(1);
+  });
+
+  test('200 - out-of-range page is clamped to last page', async () => {
+    const res = await request(app)
+      .get('/api/problems?page=999')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.page).toBe(res.body.pagination.totalPages);
+  });
+
+  test('200 - pageSize matches PROF_QUESTIONS config', async () => {
+    const res = await request(app)
+      .get('/api/problems')
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.body.pagination.pageSize).toBe(PAGE_SIZES.PROF_QUESTIONS);
+  });
+
+  test('200 - subcategory and page params work together', async () => {
+    const res = await request(app)
+      .get(`/api/problems?subcategory=${SUB_ARRAYS}&page=1`)
+      .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.page).toBe(1);
+    expect(Object.keys(res.body.questions)).toContain(SUB_ARRAYS);
+    expect(Object.keys(res.body.questions)).not.toContain(SUB_RECURSION);
+  });
+});

--- a/backend/__test__/testHelpers.js
+++ b/backend/__test__/testHelpers.js
@@ -184,12 +184,13 @@ const insertPurchase = async (userId, itemInfo = {}, isEquipped = false) => {
  * @param {number}        points      - Number of points question is worth, default 2.00
  * @param {boolean=true}  isPublished - True inserts as published, false inserts as draft. True by default.
  * @param {number=null}   ownerId     - Question.OWNER_ID to insert. Null by default.
+ * @param {string}        subcategory - Question.SUBCATEGORY to insert. 'Arrays' by default.
  * @returns {Promise<number>}           Inserted question ID
  */
-const insertQuestion = async (type, answers = [], { points = 2.00, isPublished = true, ownerId = null } = {}) => {
+const insertQuestion = async (type, answers = [], { points = 2.00, isPublished = true, ownerId = null, subcategory = 'Arrays' } = {}) => {
   const [result] = await pool.query(
     'INSERT INTO Question (QUESTION_TEXT, TYPE, SUBCATEGORY, SECTION, CATEGORY, POINTS_POSSIBLE, IS_PUBLISHED, OWNER_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-    ['Test question', type, 'Arrays', 'A', 'Introductory Programming', points, isPublished ? 1 : 0, ownerId]
+    ['Test question', type, subcategory, 'A', 'Introductory Programming', points, isPublished ? 1 : 0, ownerId]
   );
   const questionId = result.insertId;
 

--- a/backend/config/paginationConfig.js
+++ b/backend/config/paginationConfig.js
@@ -14,6 +14,7 @@ const PAGE_SIZES = Object.freeze({
                           // less than regular leaderboard because there are fewer guilds
   USER_SEARCH:        20, // Max number of users shown on a page of the user search componnet
   HISTORY_TABLE:      10, // Max number of responses shown on a page of the History Table
+  PROF_QUESTIONS:     10, // Max number of questions shown on a page of the aggregated statistics view
 });
 
 module.exports = { PAGE_SIZES };

--- a/backend/routes/problems.js
+++ b/backend/routes/problems.js
@@ -10,6 +10,9 @@
 //                 express
 //                 authMiddleware
 //                 errorHandler
+//                 paginationConfig
+//                 adminOrProf middleware
+//                 validationUtils
 //
 ////////////////////////////////////////////////////////////////
 
@@ -17,6 +20,9 @@ const express = require('express');
 const router = express.Router();
 const authMiddleware = require("../middleware/authMiddleware");
 const { asyncHandler, AppError } = require("../middleware/errorHandler");
+const { PAGE_SIZES } = require('../config/paginationConfig');
+const adminOrProf = require('../middleware/adminOrProf');
+const { normalizeDBString } = require('../utils/validationUtils');
 
 /**
  * Helper function, gets answers for a given question
@@ -62,6 +68,144 @@ router.get('/:id', authMiddleware, asyncHandler(async (req, res) => {
   const answers = await getAnswersForQuestion(id, req.db);
 
   res.json({...question, answers});
+}));
+
+/**
+ * @route   GET /api/problems
+ * @desc    Fetch all published questions broken down by subcategory, paginated.
+ *          Optional query params:
+ *            - mine=true  : only return questions owned by the requesting professor
+ *            - subcategory: filter subcategory, can provide comma separated list (case-insensitive)
+ *            - page       : page number (default 1, clamped to valid range)
+ *          Page size is controlled by PAGE_SIZES.PROF_QUESTIONS.
+ *
+ * @access  Professor, Admin
+ *
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Promise<void>} - JSON response with paginated questions grouped by subcategory
+ */
+router.get('/', adminOrProf, asyncHandler(async (req, res) => {
+  // Get query params and page size config
+  const mineOnly  = req.query.mine === 'true';
+  const rawPage   = parseInt(req.query.page);
+  const pageSize  = PAGE_SIZES.PROF_QUESTIONS;
+
+  // Support single or comma-separated subcategory values
+  // e.g. ?subcategory=Arrays
+  //      ?subcategory=Arrays,Recursion,Sorting
+  // Omit param entirely to get all subcategories
+  const subcategories = req.query.subcategory
+    ? req.query.subcategory.split(',').map(s => s.trim()).filter(Boolean)
+    : null;
+
+  // Start building WHERE clause
+  const conditions = ['q.IS_PUBLISHED = 1'];
+  const params     = [];
+
+  // mineOnly applies only to professors
+  if (mineOnly && req.user?.role === 'professor')
+  {
+    const profId = req.user?.id;
+    if (!profId)
+    {
+      throw new AppError('Professor ID is undefined', 403, 'Failed to verify professor identity');
+    }
+    // Add owner filter
+    conditions.push('q.OWNER_ID = ?');
+    params.push(profId);
+  }
+
+  if (subcategories && subcategories.length > 0)
+  {
+    // Add subcategory filter (case-insensitive)
+    conditions.push('LOWER(q.SUBCATEGORY) IN (?)');
+    params.push(subcategories.map(s => s.toLowerCase()));
+  }
+
+  // Finish building WHERE clause
+  const whereClause = conditions.join(' AND ');
+
+  // Get total count for pagination
+  const [[{ total }]] = await req.db.query(
+    `SELECT COUNT(*) AS total FROM Question q WHERE ${whereClause}`,
+    params
+  );
+
+  const totalQuestions = total;
+  const totalPages     = Math.max(1, Math.ceil(totalQuestions / pageSize));
+
+  // Clamp page to valid range
+  let page = isNaN(rawPage) || rawPage < 1 ? 1 : rawPage;
+  if (page > totalPages) page = totalPages;
+
+  const offset = (page - 1) * pageSize;
+
+  // Fetch paginated questions
+  const [questions] = await req.db.query(
+    `SELECT q.ID,
+            q.TYPE,
+            q.SECTION,
+            q.CATEGORY,
+            q.SUBCATEGORY,
+            q.POINTS_POSSIBLE,
+            q.QUESTION_TEXT,
+            q.OWNER_ID
+     FROM Question q
+     WHERE ${whereClause}
+     ORDER BY q.SUBCATEGORY ASC, q.ID ASC
+     LIMIT ? OFFSET ?`,
+    [...params, pageSize, offset]
+  );
+
+  // Pair every question on this page with its answers
+  // Batch query rather than iterating getAnswersForQuestion()
+  let questionsBySubcategory = {};
+
+  if (questions.length > 0)
+  {
+    const questionIds = questions.map(q => q.ID);
+    const [answers]   = await req.db.query(
+      `SELECT * FROM AnswerText WHERE QUESTION_ID IN (?)`,
+      [questionIds]
+    );
+
+    // Get answers
+    const answersByQuestionId = {};
+    for (const answer of answers)
+    {
+      if (!answersByQuestionId[answer.QUESTION_ID])
+      {
+        answersByQuestionId[answer.QUESTION_ID] = [];
+      }
+      answersByQuestionId[answer.QUESTION_ID].push(answer);
+    }
+
+    // Group questions by subcategory, attach answers to each
+    for (const question of questions)
+    {
+      // Prevent database inconsistencies from breaking logic
+      const sub = normalizeDBString(question.SUBCATEGORY ?? 'Unknown');
+      if (!questionsBySubcategory[sub])
+      {
+        questionsBySubcategory[sub] = [];
+      }
+      questionsBySubcategory[sub].push({
+        ...question,
+        answers: answersByQuestionId[question.ID] ?? [],
+      });
+    }
+  }
+
+  return res.status(200).json({
+    questions: questionsBySubcategory,
+    pagination: {
+      page,
+      pageSize,
+      totalQuestions,
+      totalPages,
+    },
+  });
 }));
 
 module.exports = router;

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -1900,6 +1900,67 @@ paths:
           description: URL Not Found
         500:
           description: Server Error
+
+  /problems:
+    get:
+      tags:
+        - Problems
+        - Professors
+        - Admins
+      summary: Fetch published questions broken down by subcategory.
+      operationId: getProblems
+      description: |
+        Returns all published questions grouped by subcategory and paginated
+        at PAGE_SIZES.PROF_QUESTIONS questions per page.
+ 
+        Intended for professor-facing analytics views: professors select a
+        question from this list and then call GET /stats/aggregate/{questionId}
+        to see its aggregate stats.
+ 
+        **Query parameters**
+        - `mine=true`: restrict results to questions owned by the requesting professor. Ignored for admins (admins don't 'own' questions in the general app use case).
+        - `subcategory`: Optional case-insensitive subcategory filter, accepts a single value or a comma-separated list (e.g. Arrays or Arrays,recursion,SoRtInG). Omit to return all subcategories.
+        - `page`: page number (default 1, clamped to valid range).
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: mine
+          in: query
+          required: false
+          type: boolean
+          description: |
+            When true, returns only questions owned by the requesting professor.
+            - Has no effect for admin callers.
+          example: true
+        - name: subcategory
+          in: query
+          required: false
+          type: string
+          description: |
+            Filter results to one or more subcategories.
+            - Accepts a single value or a comma-separated list (e.g. Arrays or Arrays,recursion,SoRtInG).
+            - Omit to return all subcategories.
+          example: Arrays,Recursion
+        - name: page
+          in: query
+          required: false
+          type: integer
+          description: |
+            Page number (default 1, PAGE_SIZES.PROF_QUESTIONS questions per page, clamped to valid range).
+          example: 1
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/ProblemsResponse'
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden - Professor or admin access only
+        500:
+          description: Server Error
   
   /progress/graph:
     get:
@@ -2271,6 +2332,99 @@ definitions:
         type: boolean
         example: true
         description: Programming questions only - Whether the answer passed all test cases.
+
+  ProblemsResponse:
+    type: object
+    properties:
+      questions:
+        type: object
+        description: |
+          Published questions grouped by subcategory. 
+          - Keys are subcategory name strings.
+          - Each value is an array of question objects with their associated answers.
+          - Empty object when no matching questions exist.
+        additionalProperties:
+          type: array
+          items:
+            $ref: '#/definitions/ProblemWithAnswers'
+      pagination:
+        type: object
+        properties:
+          page:
+            type: integer
+            example: 1
+            description: The actual page returned (clamped to valid range).
+          pageSize:
+            type: integer
+            example: 10
+            description: Number of questions per page (PAGE_SIZES.PROF_QUESTIONS).
+          totalQuestions:
+            type: integer
+            example: 24
+            description: Total matching published questions across all pages.
+          totalPages:
+            type: integer
+            example: 3
+            description: Total number of pages for this query.
+ 
+  ProblemWithAnswers:
+    type: object
+    properties:
+      ID:
+        type: integer
+        example: 42
+      TYPE:
+        type: string
+        example: "Multiple Choice"
+      SECTION:
+        type: string
+        example: "A"
+      CATEGORY:
+        type: string
+        example: "Data Structures"
+      SUBCATEGORY:
+        type: string
+        example: "Arrays"
+      POINTS_POSSIBLE:
+        type: number
+        example: 5.0
+      QUESTION_TEXT:
+        type: string
+        example: "What is the time complexity of binary search?"
+      OWNER_ID:
+        type: integer
+        example: 7
+        nullable: true
+      IS_PUBLISHED:
+        type: integer
+        example: 1
+        description: "Always 1, this endpoint only returns published questions."
+      answers:
+        type: array
+        description: Associated answer rows from the AnswerText table.
+        items:
+          type: object
+          properties:
+            ID:
+              type: integer
+              example: 101
+            QUESTION_ID:
+              type: integer
+              example: 42
+            ANSWER_TEXT:
+              type: string
+              example: "O(log n)"
+            IS_CORRECT:
+              type: integer
+              example: 1
+            RANK:
+              type: integer
+              example: 1
+              nullable: true
+            PLACEMENT:
+              type: string
+              example: ""
+              nullable: true
 
   UpdateUser:
     type: object

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -2395,10 +2395,6 @@ definitions:
         type: integer
         example: 7
         nullable: true
-      IS_PUBLISHED:
-        type: integer
-        example: 1
-        description: "Always 1, this endpoint only returns published questions."
       answers:
         type: array
         description: Associated answer rows from the AnswerText table.


### PR DESCRIPTION
This PR addresses [SCRUM-221: Support Professor Aggregate Stats Viewing for Individual Questions](https://knightwise.atlassian.net/browse/SCRUM-221)

This PR provides the backend support for serving professors (and admins) a paginated, aggregate list of **published** questions optionally filterable by ownership and subcategory, so that they can use **GET** `/api/stats/aggregate/:id` on individual questions.

New endpoint: **GET** `/api/problems`
- Summary: Fetch published questions broken down by subcategory.
- Details:
  - Returns all published questions grouped by subcategory and paginated at PAGE_SIZES.PROF_QUESTIONS questions per page.
  - Intended for professor-facing analytics views: professors select a question from this list and then call GET /stats/aggregate/:id to see its aggregate stats.
  - **Query parameters**
    - `mine=true`: restrict results to questions owned by the requesting professor. Ignored for admins (admins don't 'own' questions in the general app use case).
    - `subcategory`: Optional case-insensitive subcategory filter, accepts a single value or a comma-separated list (e.g. Arrays or Arrays,recursion,SoRtInG). Omit to return all subcategories.
    - `page`: page number (default 1, clamped to valid range).

- Updated the test helper `insertQuestion()` to accept an optional subcategory parameter. Made testing easier.
- Testing was added to verify functionality.
- `swagger.yaml` was updated.

- Below: All new and current tests pass.
<img width="812" height="348" alt="image" src="https://github.com/user-attachments/assets/92e2f9e1-b891-43ec-a469-e97f84bd3715" />

**End-to-end flow**
- Below: The most basic endpoint call, fetches page 1 of all questions.
<img width="1764" height="987" alt="image" src="https://github.com/user-attachments/assets/9a9b6933-6723-404e-998a-f7c31d54d822" />
...
<img width="1759" height="978" alt="image" src="https://github.com/user-attachments/assets/c802a280-5dd7-4722-9ef1-3841ead52c2d" />

- Below: Use of pagination query param changes which page is fetched.
<img width="1752" height="980" alt="image" src="https://github.com/user-attachments/assets/96b5c3de-bf6a-41ba-b1e0-be57795e4dfa" />
...
<img width="1755" height="986" alt="image" src="https://github.com/user-attachments/assets/91f7b542-fd12-457a-b8d6-5b5c722dc71c" />

- Below: Page too high clamps to last page, otherwise invalid page clamps to first page.
<img width="1740" height="969" alt="image" src="https://github.com/user-attachments/assets/f1061381-5c88-4fd2-9c60-1aacbc9bf863" />
<img width="1746" height="983" alt="image" src="https://github.com/user-attachments/assets/ac9fe3f2-e8b1-4c68-a6e5-c561ae62aceb" />

- Below: Use of subcategory query param filters only to that subcategory. Omitting the query param shows all subcategories.
<img width="1746" height="963" alt="image" src="https://github.com/user-attachments/assets/9843f2a1-6518-4473-9117-f34d7cc97394" />
...
<img width="1761" height="990" alt="image" src="https://github.com/user-attachments/assets/9d86f118-462d-434a-8786-dcccb79e957e" />

- Below: This screenshot covers a couple very important cases:
  - Subcategory query param accepts a comma separated list of case-insensitive subcategory names if the frontend wants to filter by multiple subcategories.
  - InputOutput subcategory uses its canonical name, not the display name "Input/Output".
  - Subcategory names with multiple words (e.g. Bitwise Operators, Linked Lists) are fine to leave the space in.
<img width="1767" height="985" alt="image" src="https://github.com/user-attachments/assets/91ae569e-e9f5-4f80-bd6c-9619e818fda9" />
...
<img width="1744" height="995" alt="image" src="https://github.com/user-attachments/assets/7ff1afab-5180-4e39-8f87-4851f153f8cf" />
...
<img width="1752" height="969" alt="image" src="https://github.com/user-attachments/assets/17c49e42-9949-4662-b049-95d3269386fb" />

- Below: Returns empty list on invalid subcategory.
<img width="1758" height="459" alt="image" src="https://github.com/user-attachments/assets/2ad431e0-175d-4060-9618-bf45ce2267b8" />

- Below: A professor has some draft questions and some published questions in various subcategories.
<img width="1919" height="937" alt="image" src="https://github.com/user-attachments/assets/a34c7731-a875-4e73-8a5a-cb0f50f773fe" />

- Below: Using the `mine=true` query param filters the requesting professor's **published** questions.
<img width="1750" height="956" alt="image" src="https://github.com/user-attachments/assets/c634d191-0f17-4e67-92e1-d43193a3fcbc" />
...
<img width="1741" height="972" alt="image" src="https://github.com/user-attachments/assets/c884c490-dfc6-4bab-af03-dd04a85412c3" />

- Below: An example of using all 3 query params. Note that it shows page 1 because there's only 1 page, so it clamps to the last page.
<img width="1752" height="978" alt="image" src="https://github.com/user-attachments/assets/bbc4a719-6761-49d5-9bcb-338ea2a34e54" />

- Below: **[IMPORTANT]** Filtering for Strings shows nothing since the professor's Strings question is in draft state, not published.
<img width="1750" height="455" alt="image" src="https://github.com/user-attachments/assets/7b236e59-285b-4683-88a0-a4b582f595d6" />

- Below: This is how the endpoint ideally is used. First, the professor is served the list of questions with this endpoint using any of the optional query params. In this case it's page 2 of all Algorithm Analysis questions.
<img width="1758" height="987" alt="image" src="https://github.com/user-attachments/assets/2817381a-7bd0-4398-ac1a-915972087193" />

- Below: Now the frontend has the ID it needs to get aggregate stats by individual question. Question 51 for example.
  - Note: Once users opt in and answer questions, these stats fields should show meaningful values.
<img width="1745" height="383" alt="image" src="https://github.com/user-attachments/assets/45ae944b-d399-4921-8963-8ffc8598d277" />

- Below: Similar to the stats endpoints, the aggregate problem-fetching endpoints are protected to admins and professors only. A regular student can't access them.
<img width="1749" height="334" alt="image" src="https://github.com/user-attachments/assets/882a4bf4-9c36-40ed-8bb6-96d6bae23c10" />
<img width="958" height="568" alt="image" src="https://github.com/user-attachments/assets/4c18c5ce-8c65-4425-a8aa-f216d8ddf577" />

Issues closed:
- https://knightwise.atlassian.net/browse/SCRUM-221