### PR TITLE
SCRUM-232: Implement Guild Name Tokens

### DIFF
--- a/backend/__test__/admin.test.js
+++ b/backend/__test__/admin.test.js
@@ -19,7 +19,13 @@
 const request = require("supertest");
 const jwt = require("jsonwebtoken");
 const { app, pool } = require("../server");
-const { TEST_USER, verifyTestDatabase, insertQuestion } = require("./testHelpers");
+const { TEST_USER,
+        verifyTestDatabase,
+        insertQuestion,
+        getAuthToken,
+        insertUser,
+        insertGuildWithOwner,
+      } = require("./testHelpers");
 const { ITEM_TYPES } = require('../../shared/itemConfig');
 
 // Mock Mailjet
@@ -379,5 +385,120 @@ describe("Admin Routes", () => {
         .send({ itemType: ITEM_TYPES.FLAIR, itemCost: 5.00, itemName: 'Test Flair' });
 
       expect(res.status).toBe(401);
+    });
+
+    // Test admin Guild creation (allows arbitrary Guild names and specified Owner ID)
+    describe('POST /api/admin/guilds', () => {
+
+      let userId;
+
+      beforeAll(async () => {
+        // create test user to own Guilds
+        userId = await insertUser({ username: 'guild_owner', email: 'guild_owner@test.com' });
+      });
+
+      afterEach(async () => {
+        await pool.query('DELETE FROM GuildMember');
+        await pool.query('DELETE FROM Guild');
+      });
+
+      afterAll(async () => {
+        await pool.query('DELETE FROM User WHERE ID = ?', [userId]);
+      });
+
+      test('201 - successfully creates guild and inserts owner as member', async () => {
+        const res = await request(app)
+          .post('/api/admin/guilds')
+          .set('Authorization', `Bearer ${token}`)
+          .send({ name: 'Admin Guild', ownerId: userId });
+
+        expect(res.status).toBe(201);
+        expect(res.body).toHaveProperty('guildId');
+
+        // verify guild exists
+        const [guilds] = await pool.query('SELECT * FROM Guild WHERE ID = ?', [res.body.guildId]);
+        expect(guilds).toHaveLength(1);
+        expect(guilds[0].NAME).toBe('Admin Guild');
+
+        // verify owner membership
+        const [members] = await pool.query(
+          'SELECT ROLE FROM GuildMember WHERE USER_ID = ? AND GUILD_ID = ?',
+          [userId, res.body.guildId]
+        );
+        expect(members).toHaveLength(1);
+        expect(members[0].ROLE).toBe('Owner');
+      });
+
+      test('400 - missing guild name', async () => {
+        const res = await request(app)
+          .post('/api/admin/guilds')
+          .set('Authorization', `Bearer ${token}`)
+          .send({ ownerId: userId });
+
+        expect(res.status).toBe(400);
+      });
+
+      test('400 - invalid owner ID', async () => {
+        const res = await request(app)
+          .post('/api/admin/guilds')
+          .set('Authorization', `Bearer ${token}`)
+          .send({ name: 'Guild Invalid', ownerId: 'not-a-number' });
+
+        expect(res.status).toBe(400);
+      });
+
+      test('404 - owner does not exist', async () => {
+        const res = await request(app)
+          .post('/api/admin/guilds')
+          .set('Authorization', `Bearer ${token}`)
+          .send({ name: 'Guild Unknown', ownerId: 999999 });
+
+        expect(res.status).toBe(404);
+      });
+
+      test('409 - owner already in a guild', async () => {
+        // create guild for other user
+        const otherId = await insertUser({ username: 'otheruser', email: 'otheruser@test.com' });
+        await insertGuildWithOwner(otherId, { name: 'Existing Guild' });
+
+        const res = await request(app)
+          .post('/api/admin/guilds')
+          .set('Authorization', `Bearer ${token}`)
+          .send({ name: 'New Guild', ownerId: otherId });
+
+        expect(res.status).toBe(409);
+
+        // Cleanup
+        await pool.query(`DELETE FROM User WHERE ID = ${otherId}`);
+      });
+
+      test('409 - guild name already taken', async () => {
+        // create guild for other user
+        const user1 = await insertUser({ username: 'user1', email: 'user1@test.com' });
+        await insertGuildWithOwner(user1, { name: 'Duplicate Guild' });
+
+        const user2 = await insertUser({ username: 'user2', email: 'user2@test.com' });
+
+        const res = await request(app)
+          .post('/api/admin/guilds')
+          .set('Authorization', `Bearer ${token}`)
+          .send({ name: 'Duplicate Guild', ownerId: user2 });
+
+        expect(res.status).toBe(409);
+
+        // Cleanup
+        await pool.query('DELETE FROM User WHERE ID IN (?, ?)', [user1, user2]);
+      });
+
+      test('401 - non-admin cannot create guild', async () => {
+        const nonAdminToken = await getAuthToken();
+
+        const res = await request(app)
+          .post('/api/admin/guilds')
+          .set('Authorization', `Bearer ${nonAdminToken}`)
+          .send({ name: 'Admin Only', ownerId: userId });
+
+        expect(res.status).toBe(401);
+      });
     });
 })

--- a/backend/__test__/guildTests/guild.test.js
+++ b/backend/__test__/guildTests/guild.test.js
@@ -30,6 +30,7 @@ const {
         insertUser,
         insertGuildWithOwner,
         insertGuildMember,
+        getValidGuildName,
       } = require('../testHelpers');
 
 // Mock Discord webhook
@@ -68,18 +69,24 @@ afterAll(async () => {
 describe('POST /api/guilds', () => {
 
   test('201 - successfully creates guild and inserts owner as member', async () => {
+    // Get valid name and name token
+    const { name, nameToken } = await getValidGuildName(token);
     const res = await request(app)
       .post('/api/guilds')
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Ancient Wolves' });
+      .send({ name, nameToken });
 
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('guildId');
+    expect(res.body).toHaveProperty('name');
+    expect(res.body.name).toBe(name);
+    expect(res.body).toHaveProperty('message');
+    expect(res.body.message).toContain('successfully');
 
     // Verify guild row exists
     const [guilds] = await pool.query('SELECT * FROM Guild WHERE ID = ?', [res.body.guildId]);
     expect(guilds).toHaveLength(1);
-    expect(guilds[0].NAME).toBe('Ancient Wolves');
+    expect(guilds[0].NAME).toBe(name);
 
     // Verify owner member row exists
     const [members] = await pool.query(
@@ -90,11 +97,13 @@ describe('POST /api/guilds', () => {
     expect(members[0].ROLE).toBe('Owner');
   });
 
-  test('notifies Discord on guild creation', async () => {
+  test('201 - notifies Discord on guild creation', async () => {
+    // Get valid name and name token
+    const { name, nameToken } = await getValidGuildName(token);
     const res = await request(app)
       .post('/api/guilds')
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Webhook Guild' });
+      .send({ name, nameToken });
 
     expect(res.status).toBe(201);
     expect(notifyUserEvent).toHaveBeenCalledTimes(1);
@@ -121,25 +130,69 @@ describe('POST /api/guilds', () => {
     expect(res.status).toBe(400);
   });
 
-  test('409 - user already in a guild', async () => {
-    const guildId = await insertGuildWithOwner(userId, { name: 'First Guild' });
+  test('400 - missing nameToken', async () => {
+    const res = await request(app)
+      .post('/api/guilds')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Ancient Wolves' }); // Can't give arbitrary names anymore!
+
+    expect(res.status).toBe(400);
+  });
+
+  test('401 - rejects tampered nameToken', async () => {
+    // Get valid name and name token
+    const { name, nameToken } = await getValidGuildName(token);
+
+    // Lets mess with the JWT a little bit
+    const badNameToken = nameToken.slice(0, -1) + 'x';
 
     const res = await request(app)
       .post('/api/guilds')
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Second Guild' });
+      .send({ name, nameToken: badNameToken });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('400 - name does not match token payload', async () => {
+    // Get valid name and name token
+    const { name, nameToken } = await getValidGuildName(token);
+
+    const res = await request(app)
+      .post('/api/guilds')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Evil Name', nameToken });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('409 - user already in a guild', async () => {
+    await insertGuildWithOwner(userId, { name: 'First Guild' });
+
+    // Get valid name and name token for second guild
+    const { name, nameToken } = await getValidGuildName(token);
+    const res = await request(app)
+      .post('/api/guilds')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name, nameToken });
 
     expect(res.status).toBe(409);
   });
 
   test('409 - guild name already taken', async () => {
-    const otherId = await insertUser({ username: 'otherown', email: 'otherown@test.com' });
-    await insertGuildWithOwner(otherId, { name: 'Taken Name' });
+    // Get valid name and name token
+    const { name, nameToken } = await getValidGuildName(token);
 
+    // But wait, another user somehow gets that name first
+    // (technically a possible race condition)
+    const otherId = await insertUser({ username: 'otherown', email: 'otherown@test.com' });
+    await insertGuildWithOwner(otherId, { name });
+
+    // TEST_USER can't get the name now
     const res = await request(app)
       .post('/api/guilds')
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'Taken Name' });
+      .send({ name, nameToken });
 
     expect(res.status).toBe(409);
   });

--- a/backend/__test__/guildTests/guildName.test.js
+++ b/backend/__test__/guildTests/guildName.test.js
@@ -11,13 +11,15 @@
 //                 mysql2 connection pool (server.js)
 //                 testHelpers
 //                 guildNames
+//                 jsonwebtoken
 //
 ////////////////////////////////////////////////////////////////
 
 const request = require('supertest');
 const { app, pool } = require('../../server');
-const { getAuthToken, verifyTestDatabase, insertGuild } = require('../testHelpers');
+const { getAuthToken, verifyTestDatabase, insertGuild, TEST_USER } = require('../testHelpers');
 const guildNames = require('../../config/guildNames');
+const jwt = require('jsonwebtoken');
 
 // Mock tiny word bank so we don't have to insert
 // hundreds of test guilds to exhaust all available names
@@ -27,6 +29,7 @@ jest.mock('../../config/guildNames', () => ({
 }));
 
 let token;
+let userId;
 let guildOwnerIds = [];
 
 // Guild owners are unique so we'll need 4 users
@@ -41,6 +44,12 @@ const GUILD_OWNERS = [
 beforeAll(async () => {
   await verifyTestDatabase(pool);
   token = await getAuthToken();
+
+  const [[{ ID }]] = await pool.query(
+    'SELECT ID FROM User WHERE USERNAME = ?',
+    [TEST_USER.username]
+  );
+  userId = ID;
 
   // Insert guild owners for test
   for (const u of GUILD_OWNERS)
@@ -112,6 +121,22 @@ describe('GET /api/guilds/name/generate', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('Blazing Dragons');
+  });
+
+  test('200 - returns signed name token JWT with correct payload', async () => {
+    const res = await request(app)
+      .get('/api/guilds/name/generate')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    // Verify token payload
+    expect(res.body).toHaveProperty('nameToken');
+    const decoded = jwt.verify(res.body.nameToken, process.env.JWT_SECRET);
+    expect(decoded.guildName).toBe(res.body.name);
+    expect(decoded).toHaveProperty('userId');
+    expect(decoded.userId).toBe(userId);
+    expect(decoded).toHaveProperty('exp');
   });
 
   test('503 - all guild name combinations are taken', async () => {

--- a/backend/__test__/testHelpers.js
+++ b/backend/__test__/testHelpers.js
@@ -39,6 +39,21 @@ const TEST_PROF = {
 };
 
 /**
+ * Fetches a valid Guild name through the name generation endpoint
+ * Use this for Guild tests that require a name token
+ *
+ * @param {string} token - User token to call generate endpoint with
+ * @returns {Promise<{ name: string, nameToken: string }>} Guild name and valid name token
+ */
+const getValidGuildName = async (token) => {
+  const res = await request(app)
+    .get('/api/guilds/name/generate')
+    .set('Authorization', `Bearer ${token}`);
+
+  return res.body;
+};
+
+/**
  * Inserts a Response row with the specified parameters
  * Use this for adding deterministic test data for analytics/stats tests
  * Does NOT trigger grading, currency awarding, or any other side effects
@@ -326,6 +341,7 @@ async function verifyTestDatabase(pool)
 module.exports = {
   TEST_USER,
   TEST_PROF,
+  getValidGuildName,
   insertResponse,
   insertUser,
   insertGuild,

--- a/backend/controllers/guildController.js
+++ b/backend/controllers/guildController.js
@@ -13,6 +13,7 @@
 //                 itemConfig
 //                 guildConfig
 //                 discordWebhook
+//                 jsonwebtoken
 //
 ////////////////////////////////////////////////////////////////
 
@@ -21,6 +22,7 @@ const guildNames = require('../config/guildNames');
 const { EQUIP_LIMITS } = require('../../shared/itemConfig');
 const { MAX_GUILD_SIZE } = require('../../shared/guildConfig');
 const { notifyUserEvent } = require('../services/discordWebhook');
+const jwt = require('jsonwebtoken');
 
 /**
  * Helper function, asserts that the requesting user is a member of the guild
@@ -116,6 +118,9 @@ const assertGuildExists = async (db, guildId, context) => {
  * @route   GET /api/guilds/name/generate
  * @desc    Generate a unique guild name in the form "[adjective] [plural noun]"
  *          Guaranteed to generate a name that isn't taken yet by a guild.
+ *          Signs a JWT name token that is checked in createGuild
+ *          to ensure users can't create a Guild with an arbitrary name
+ *          other than the ones produced by this endpoint.
  * @access  Protected
  *
  * @param {import('express').Request}  req - Express request object
@@ -163,14 +168,24 @@ const generateGuildName = asyncHandler(async (req, res) => {
 
   // Return a random name from the list
   const name = availableNames[Math.floor(Math.random() * availableNames.length)];
-  return res.status(200).json({ name });
+
+  // Sign name token
+  const token = jwt.sign(
+    { guildName: name, userId: req.user.id },
+    process.env.JWT_SECRET,
+    { expiresIn: '5m' }
+  );
+
+  return res.status(200).json({ name, nameToken: token });
 });
 
 /**
  * @route   POST /api/guilds
- * @desc    Create a new guild. Requesting user becomes Owner.
+ * @desc    Create a new Guild for a user. Requesting user becomes Owner.
  *          Atomically inserts Guild and GuildMember rows in a transaction.
  *          User must not already be in a guild or own one.
+ *          Prevents arbitrary name choice by verifying a dedicated
+ *          name token created by GET /api/guilds/name/generate
  * @access  Protected
  *
  * @param {import('express').Request}  req - Express request object
@@ -182,7 +197,7 @@ const generateGuildName = asyncHandler(async (req, res) => {
 const createGuild = asyncHandler(async (req, res) => {
   const context = 'createGuild';
   const userId  = req.user.id;
-  const { name } = req.body;
+  const name = req.guildName; // Verified by validateNameToken middleware
 
   if (!name || !name.trim())
   {
@@ -230,7 +245,7 @@ const createGuild = asyncHandler(async (req, res) => {
 
     // Notify Discord and return success
     notifyUserEvent(`Guild created: ${name} (ID ${guildId}) by user ${userId}`);
-    return res.status(201).json({ message: 'Guild created successfully', guildId });
+    return res.status(201).json({ message: 'Guild created successfully', guildId, name });
   }
   catch (err)
   {

--- a/backend/middleware/validateNameToken.js
+++ b/backend/middleware/validateNameToken.js
@@ -1,0 +1,77 @@
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     Daniel Landsman
+//  File:          validateNameToken.js
+//  Description:   Express middleware that verifies a Guild name
+//                 token created by GET /api/guilds/name/generate.
+//                 Attaches the verified Guild name to req.guildName.
+//
+//  Dependencies:  jsonwebtoken
+//                 errorHandler
+//
+////////////////////////////////////////////////////////////////
+
+const jwt = require('jsonwebtoken');
+const { AppError } = require('./errorHandler');
+
+if (!process.env.JWT_SECRET)
+{
+  throw new Error('JWT_SECRET environment variable not configured');
+}
+
+/**
+ * Middleware to validate a Guild name reservation token
+ *
+ * Expects req.body.nameToken to be a JWT signed by the server
+ * via GET /api/guilds/name/generate. 
+ * 
+ * Verifies token, confirms it's for the requesting user, attaches reserved
+ * name to req.guildName before calling next().
+ *
+ * @param {import('express').Request}      req  - Express request object
+ * @param {import('express').Response}     res  - Express response object
+ * @param {import('express').NextFunction} next - Next middleware function
+ *
+ * @returns {void} Calls next() or throws AppError
+ */
+const validateNameToken = (req, res, next) => {
+  const { nameToken } = req.body;
+
+  if (!nameToken)
+  {
+    throw new AppError('Missing Guild name token', 400, 'A valid name token is required to create a Guild.');
+  }
+
+  try
+  {
+    const decoded = jwt.verify(nameToken, process.env.JWT_SECRET);
+
+    if (decoded.userId !== req.user.id)
+    {
+      throw new AppError('Name token user mismatch', 400, 'Invalid name token.');
+    }
+
+    if (decoded.guildName !== req.body.name)
+    {
+      throw new AppError('Name token guildName mismatch', 400, 'Invalid name token.');
+    }
+
+    // Verification successful, pass on the Guild name
+    req.guildName = decoded.guildName;
+    next();
+  }
+  catch (err)
+  {
+    if (err instanceof AppError) throw err;
+
+    const message = err.name === 'TokenExpiredError'
+      ? 'Your Guild name choice expired, please shuffle and try again.'
+      : 'Invalid name token.';
+
+    throw new AppError(`Name token verification failed: ${err.message}`, 400, message);
+  }
+};
+
+module.exports = validateNameToken;

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -15,11 +15,10 @@
 //                 bcryptjs
 //                 otp-generator
 //                 errorHandler
-//                 authMiddleware
-//                 requireRole
 //                 node-mailjet
 //                 discordWebhook service (notifyUserEvent)
 //                 itemConfig
+//                 validationUtils
 //
 ////////////////////////////////////////////////////////////////
 
@@ -29,11 +28,10 @@ const router = express.Router();
 
 const { asyncHandler, AppError } = require('../middleware/errorHandler');
 const adminMiddleware = require("../middleware/adminMiddleware");
-const authMiddleware = require('../middleware/authMiddleware');
 const adminOrProf = require('../middleware/adminOrProf');
-const requireRole = require('../middleware/requireRole');
 const { notifyUserEvent } = require("../services/discordWebhook");
 const { ITEM_TYPES } = require('../../shared/itemConfig');
+const { parseUserId } = require('../utils/validationUtils');
 
 // Mailjet for sending professor verified email
 const Mailjet = require("node-mailjet");
@@ -754,6 +752,92 @@ router.delete('/store/items/:id', adminMiddleware, asyncHandler(async (req, res)
   notifyUserEvent(`Store item deleted: ${item.NAME} (ID ${itemId})`);
 
   return res.status(200).json({ message: 'Store item deleted successfully' });
+}));
+
+/**
+ * @route   POST /api/admin/guilds
+ * @desc    Create a Guild with an arbitrary name and specifiable owner ID.
+ * @access  Admin
+ * 
+ * @param {import('express').Request}  req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @throws  {AppError} 400                 - Missing name field or throwable by parseUserId
+ * @throws  {AppError} 404                 - Provided Owner user not found
+ * @throws  {AppError} 409                 - Guild name already taken or provided Owner already in a Guild
+ * @returns {Promise<void>}                - Sends HTTP/JSON confirming Guild creation
+ */
+router.post('/guilds', adminMiddleware, asyncHandler(async (req, res) => {
+  const context = 'admin:createGuild';
+  const { name, ownerId } = req.body;
+
+  // Verify Guild name is actually given and proposed owner is a positive integer
+  if (!name || !name.trim())
+  {
+    throw new AppError(`[${context}] Missing guild name`, 400, 'Guild name is required');
+  }
+  const validatedOwnerId = parseUserId(ownerId, context);
+
+  // Ensure a Guild doesn't already exist with this name
+  const [[existingGuild]] = await req.db.query(
+    'SELECT ID FROM Guild WHERE NAME = ?',
+    [name]
+  );
+  if (existingGuild)
+  {
+    throw new AppError(`[${context}] Guild name already taken: ${name}`, 409, 'Guild name is already taken');
+  }
+
+  // Ensure proposed owner ID corresponds to an existing user
+  const [[ownerExists]] = await req.db.query(
+    'SELECT ID FROM User WHERE ID = ?',
+    [validatedOwnerId]
+  );
+  if (!ownerExists)
+  {
+    throw new AppError(`[${context}] Owner not found: ${validatedOwnerId}`, 404, 'Owner user not found');
+  }
+
+  // User must not already be a Guild member
+  const [[existingMembership]] = await req.db.query(
+    'SELECT GUILD_ID FROM GuildMember WHERE USER_ID = ?',
+    [validatedOwnerId]
+  );
+  if (existingMembership)
+  {
+    throw new AppError(`[${context}] User ${validatedOwnerId} is already in a Guild`, 409, 'Cannot create Guild under an Owner already in a Guild.');
+  }
+
+  // Create Guild and establish owner atomically
+  const conn = await req.db.getConnection();
+  try
+  {
+    await conn.beginTransaction();
+
+    const [guildResult] = await conn.query(
+      'INSERT INTO Guild (NAME, OWNER_ID) VALUES (?, ?)',
+      [name.trim(), validatedOwnerId]
+    );
+    const guildId = guildResult.insertId;
+
+    await conn.query(
+      'INSERT INTO GuildMember (USER_ID, GUILD_ID, ROLE) VALUES (?, ?, ?)',
+      [validatedOwnerId, guildId, 'Owner']
+    );
+
+    await conn.commit();
+
+    notifyUserEvent(`Guild created by admin: ${name} (ID ${guildId}), Owner ID ${validatedOwnerId}`);
+    return res.status(201).json({ message: 'Guild created successfully', guildId });
+  }
+  catch (err)
+  {
+    await conn.rollback();
+    throw err;
+  }
+  finally
+  {
+    conn.release();
+  }
 }));
 
 module.exports = router;

--- a/backend/routes/guilds.js
+++ b/backend/routes/guilds.js
@@ -16,6 +16,7 @@
 const express    = require('express');
 const router     = express.Router();
 const authMiddleware = require('../middleware/authMiddleware');
+const validateNameToken = require('../middleware/validateNameToken');
 
 const {
   generateGuildName,
@@ -45,10 +46,12 @@ router.get('/name/generate', authMiddleware, generateGuildName);
 
 /**
  * @route   POST /api/guilds
- * @desc    Create a new guild
+ * @desc    Create a new Guild for a user
+ *          Prevents arbitrary name choice by verifying a dedicated
+ *          name token created by GET /api/guilds/name/generate
  * @access  Protected
  */
-router.post('/', authMiddleware, createGuild);
+router.post('/', authMiddleware, validateNameToken, createGuild);
 
 //////////////////////////////////////////////////////////////////////////////////////
 //

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -1789,7 +1789,7 @@ paths:
       - Admins
       summary: Create a Guild (admin)
       operationId: createGuildAdmin
-      description: Creates a Guild. Unlike the user-facing endpoint POST /api/guilds, this does not require a JWT name token, so a Guild can be created with an arbitrary name. An Owner ID also has to be specified, which much correspond to a valid user.
+      description: Creates a Guild. Unlike the user-facing endpoint POST /api/guilds, this does not require a JWT name token, so a Guild can be created with an arbitrary name. An Owner ID also has to be specified, which must correspond to a valid user.
       security:
         - BearerAuth: []
       parameters:

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -901,6 +901,7 @@ paths:
         - Guaranteed to return a name not already in use.
         - Intended to be called repeatedly during guild creation while the user shuffles names.
         - The name is not persisted until POST /guilds is called.
+        - This endpoint signs a JWT name token that is to be passed to POST /api/guilds to validate that a Guild is not being created with an arbitrary name. This JWT expires in 5 minutes.
       security:
         - BearerAuth: []
       produces:
@@ -928,6 +929,7 @@ paths:
         - Atomically inserts Guild and GuildMember rows in a transaction.
         - User must not already be in a guild.
         - Guild name must be unique.
+        - Request must contain a valid nameToken signed by GET /api/guilds/name/generate
       security:
         - BearerAuth: []
       parameters:
@@ -1778,6 +1780,37 @@ paths:
           description: Unauthorized
         404:
           description: Professor Not Found
+        500:
+          description: Server Error
+
+  /admin/guilds:
+    post:
+      tags:
+      - Admins
+      summary: Create a Guild (admin)
+      operationId: createGuildAdmin
+      description: Creates a Guild. Unlike the user-facing endpoint POST /api/guilds, this does not require a JWT name token, so a Guild can be created with an arbitrary name. An Owner ID also has to be specified, which much correspond to a valid user.
+      security:
+        - BearerAuth: []
+      parameters:
+      - name: name
+        in: body
+        required: true
+        type: string
+        description: The name of the Guild to create. Can be anything (except an empty string).
+      - name: ownerId
+        required: true
+        type: integer
+        description: The ID of the user to assign as the Owner of this new Guild. Must be a valid user ID corresponding to an existing user that doesn't currently belong to a Guild.
+      responses:
+        200:
+          description: OK
+        401:
+          description: Unauthorized
+        404:
+          description: Provided Owner not found
+        409:
+          description: Guild name taken or provided Owner already in a Guild
         500:
           description: Server Error
 
@@ -2818,16 +2851,24 @@ definitions:
       name:
         type: string
         example: "Blazing Dragons"
+      nameToken:
+        type: string
+        example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5"
 
   CreateGuild:
     type: object
     required:
       - name
+      - nameToken
     properties:
       name:
         type: string
         example: "Ancient Wolves"
         description: The name for the new guild. Must be unique.
+      nameToken:
+        type: string
+        example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5"
+        description: JWT signed by GET /api/guilds/name/generate that validates a Guild is not being created with an arbitrary name.
 
   CreateGuildResponse:
     type: object
@@ -2838,6 +2879,9 @@ definitions:
       guildId:
         type: integer
         example: 7
+      name:
+        type: string
+        example: "Twisted Dragons"
 
   GuildInfoResponse:
     type: object

--- a/frontend/src/pages/GuildsPage.tsx
+++ b/frontend/src/pages/GuildsPage.tsx
@@ -216,6 +216,7 @@ const GuildsPage: React.FC = () => {
   const [invites, setInvites] = useState<GuildInvite[]>([]);
   const [nameSuggestion, setNameSuggestion] = useState("");
   const [createName, setCreateName] = useState("");
+  const [nameToken, setNameToken] = useState("");
   const [contributionAmount, setContributionAmount] = useState(100);
 
   const [searchInput, setSearchInput] = useState("");
@@ -700,15 +701,23 @@ const GuildsPage: React.FC = () => {
     setNotice(null);
 
     try {
-      const response = await api.get<{ name: string }>("/api/guilds/name/generate");
+      const response = await api.get<{ name: string; nameToken: string }>("/api/guilds/name/generate");
       setNameSuggestion(response.data.name || "");
       setCreateName(response.data.name || "");
+      setNameToken(response.data.nameToken || ""); // Set token to verify Guild name is from the generate endpoint
     } catch (requestError) {
       setError(getApiMessage(requestError, "Failed to generate guild name."));
     }
   };
 
   const handleCreateGuild = async () => {
+    // Check name token 
+    if (!nameToken)
+    {
+      setError("Please generate a Guild name first.");
+      return;
+    }
+
     const trimmedName = createName.trim();
     if (!trimmedName) {
       setError("Guild name is required.");
@@ -720,7 +729,7 @@ const GuildsPage: React.FC = () => {
     setNotice(null);
 
     try {
-      const response = await api.post<{ guildId: number; message: string }>("/api/guilds", { name: trimmedName });
+      const response = await api.post<{ guildId: number; name: string; message: string }>("/api/guilds", { name: trimmedName, nameToken });
       setNotice(response.data.message || "Guild created.");
       setGuildId(response.data.guildId);
       setTab("overview");


### PR DESCRIPTION
This PR addresses [SCRUM-232: Prevent Arbitrarily-Named Guild Creation](https://knightwise.atlassian.net/browse/SCRUM-232)
- Before, any authorized user with a valid login JWT could call **POST** `/api/guilds` through Postman to create a Guild with any arbitrary name. This defeated the entire purpose of having random name generation (which was to prevent arbitrary name creation).
- This PR implements a separate token flow, where **GET** `/api/guilds/name/generate` signs a JWT with Guild name and user info. This token is then passed to **POST** `/api/guilds` and validated. This ensures that only clean names from our endpoints are used.

# Backend Support
- All new API changes are documented in `swagger.yaml`.
- Modified endpoints:
  - **GET** `/api/guilds/name/generate`
    - Now signs a JWT name token and provides it in the response body.
  - **POST** `/api/guilds`
    - Now takes that token and validates it before creating a Guild.
    - Now also returns Guild name of created Guild in response body because that is useful info.
- New endpoints:
  - **POST** `/api/admin/guilds`
    - I didn't want to take away _our_ ability to create Guilds with arbitrary names, so this is the answer.
    - Admin must provide an arbitrary non-empty name as well as a valid Owner ID to assign the guild to.
      - Name must still be unique.
      - Owner must actually exist as a user and not already be in a Guild.
- Miscellaneous changes:
  - Created `validateNameToken.js` as its own middleware file so I didn't bloat the Guild controller too much with validation logic.
  - Added a test helper function to generate a valid Guild name and token since the tests now must test the token flow.

# Frontend Support
- `GuildsPage.tsx`
  - Minimal changes to support the new Guild name token functionality:
    - Created state variable for name token and set it after call to Guild name generation endpoint.
    - Check for name token in `handleCreateGuild()` and pass it to the create Guild endpoint.
    - Updated type annotation to indicate that Guild creation endpoint now also returns the Guild name.

# Testing & Use Cases
- Below: All new and current test cases pass.
<img width="796" height="334" alt="image" src="https://github.com/user-attachments/assets/81e001e7-4d85-4313-82b3-f5a17dc95d1a" />

**End-to-End Use Cases for User-Facing Guild Creation**
- Below: Upon random name generation, the name token is generated and attached to the **response**.
<img width="1910" height="938" alt="image" src="https://github.com/user-attachments/assets/a42ddc7b-1b42-4b3e-9a3b-257e6ecdcc9a" />
- Below: Upon Guild creation, the name token is attached to the **request**.
<img width="1919" height="936" alt="image" src="https://github.com/user-attachments/assets/9e41d99c-9f91-4d6d-ace2-bfdc2c556735" />
- Below: Response of successful Guild creation now also returns name of the new Guild.
<img width="1917" height="462" alt="image" src="https://github.com/user-attachments/assets/68d52f38-f20e-4dd8-b36e-c73b548abfec" />

- Below: Arbitrary Guild names are no longer supported for non-admin users.
<img width="1757" height="495" alt="image" src="https://github.com/user-attachments/assets/3fbe8fdf-9628-4b7b-97bb-aafd538bf4d5" />

- Below: You must call the name generation endpoint first, which generates the name token.
<img width="1753" height="413" alt="image" src="https://github.com/user-attachments/assets/6ada2e84-3643-4aa6-ac7a-d236dd0062a9" />

- Below: Guild creation doesn't accept **wrong** tokens.
<img width="1752" height="540" alt="image" src="https://github.com/user-attachments/assets/4890310a-12c6-4432-9fe4-5d81f971fe53" />

- Below: Guild creation doesn't accept **correct** tokens accompanied with a **non-matching name**.
- The name provided **must** match the name in the token payload.
<img width="1754" height="553" alt="image" src="https://github.com/user-attachments/assets/6b4e31c6-6b5f-4d62-8553-e506bbb119b4" />

- Below: If the token is correct and the name matches, the Guild can be created.
<img width="1754" height="585" alt="image" src="https://github.com/user-attachments/assets/5cef2886-1f0d-4d7e-a3f1-f9a8a987583b" />
<img width="1909" height="936" alt="image" src="https://github.com/user-attachments/assets/eb3ede01-516a-4c5c-b2d3-93f59f5cfd71" />

**End-to-End Use Cases for Admin Guild Creation**
- Below: The admin endpoint cannot be access without a proper admin token.
<img width="1749" height="615" alt="image" src="https://github.com/user-attachments/assets/a4459b75-7d0f-4951-b95b-fb1683a38a8d" />

- Below: Admin can create a Guild with an arbitrary name, assigning an existing user as the Owner.
<img width="1755" height="500" alt="image" src="https://github.com/user-attachments/assets/99153470-7877-41db-8cbc-79650021aa83" />
<img width="1911" height="943" alt="image" src="https://github.com/user-attachments/assets/5eb0c631-c96d-4fc5-988f-99e57e9365fa" />

- Below: Fail case: Empty Guild name.
<img width="1755" height="503" alt="image" src="https://github.com/user-attachments/assets/1ccd7330-3ff1-409d-bd70-306d9585025c" />

- Below: Fail case: Invalid user ID format (must be positive integer).
<img width="1761" height="504" alt="image" src="https://github.com/user-attachments/assets/7b59acde-cb8a-4a75-b001-37738f84887f" />

- Below: Fail case: User ID doesn't correspond to an existing user.
<img width="1759" height="506" alt="image" src="https://github.com/user-attachments/assets/dddd2803-d7d0-40e4-aaad-547afb946160" />

- Below: Fail case: Guild name must be unique.
<img width="1764" height="531" alt="image" src="https://github.com/user-attachments/assets/81c72df9-393f-494c-a723-4df0011dc5ce" />

- Below: Fail case: Provided Owner user must not already be in a Guild.
<img width="1763" height="517" alt="image" src="https://github.com/user-attachments/assets/68b42fd7-aaab-4f6f-a857-55e56cd2e80b" />
