### PR TITLE
SCRUM-234: Add Performance Metric to Professor Aggregate Statistics

### DIFF
--- a/backend/__test__/stats.test.js
+++ b/backend/__test__/stats.test.js
@@ -269,6 +269,24 @@ describe('GET /api/stats/aggregate', () => {
     expect(res.status).toBe(401);
   });
 
+  test('200 - response shape includes medianPerformanceMetric', async () => {
+    const res = await request(app)
+        .get('/api/stats/aggregate')
+        .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('medianPerformanceMetric');
+  });
+
+  test('200 - median performance metric is within valid range', async () => {
+    const res = await request(app)
+        .get('/api/stats/aggregate')
+        .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.medianPerformanceMetric).toBeGreaterThanOrEqual(0);
+    expect(res.body.medianPerformanceMetric).toBeLessThanOrEqual(1);
+  });
 });
 
 // Test aggregate stats for a single question
@@ -342,6 +360,7 @@ describe('GET /api/stats/aggregate/:questionId', () => {
     expect(res.status).toBe(200);
     expect(res.body.medianAccuracy).toBeNull();
     expect(res.body.medianElapsedTime).toBeNull();
+    expect(res.body.medianPerformanceMetric).toBeNull();
     expect(res.body.responseCount).toBe(0);
 
     // Cleanup
@@ -409,5 +428,14 @@ describe('GET /api/stats/aggregate/:questionId', () => {
       .get(`/api/stats/aggregate/${questionId}`);
 
     expect(res.status).toBe(401);
+  });
+
+  test('200 - response shape includes medianPerformanceMetric', async () => {
+    const res = await request(app)
+        .get(`/api/stats/aggregate/${questionId}`)
+        .set('Authorization', `Bearer ${profToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('medianPerformanceMetric');
   });
 });

--- a/backend/controllers/statsController.js
+++ b/backend/controllers/statsController.js
@@ -15,15 +15,15 @@
 ////////////////////////////////////////////////////////////////
 
 const { asyncHandler, AppError } = require('../middleware/errorHandler');
-const { computeMedian } = require('../utils/analyticsModel');
+const { computeMedian, computePerformanceMetric } = require('../utils/analyticsModel');
 const { normalizeDBString } = require('../utils/validationUtils');
 
 /**
- * Helper function, computes median accuracy and median elapsed time
- * for a given set of responses
+ * Helper function, computes median accuracy, median elapsed time,
+ * and median AE performance metric for a given set of responses
  *
  * @param {Array} responses - Rows from Response JOIN User query
- * @returns {{ medianAccuracy: number|null, medianElapsedTime: number|null }}
+ * @returns {{ medianAccuracy: number|null, medianElapsedTime: number|null, medianPerformanceMetric: number|null }}
  */
 const computeAggregateStats = (responses) => {
   const accuracies   = responses.map(r => r.POINTS_POSSIBLE > 0
@@ -34,9 +34,17 @@ const computeAggregateStats = (responses) => {
     .filter(r => r.ELAPSED_TIME != null)
     .map(r => r.ELAPSED_TIME);
 
+  const performanceMetrics = responses.map(r => computePerformanceMetric({
+    normalizedScore: r.POINTS_POSSIBLE > 0 ? r.POINTS_EARNED / r.POINTS_POSSIBLE : 0,
+    elapsedTime:     r.ELAPSED_TIME ?? null,
+    subcategory:     normalizeDBString(r.SUBCATEGORY ?? ''),
+    type:            normalizeDBString(r.TYPE ?? ''),
+  }));
+
   return {
-    medianAccuracy:    computeMedian(accuracies),
-    medianElapsedTime: computeMedian(elapsedTimes),
+    medianAccuracy:           computeMedian(accuracies),
+    medianElapsedTime:        computeMedian(elapsedTimes),
+    medianPerformanceMetric:  computeMedian(performanceMetrics),
   };
 };
 
@@ -45,7 +53,7 @@ const computeAggregateStats = (responses) => {
  * computes aggregate stats per subcategory
  *
  * @param {Array} responses - Rows from Response JOIN User JOIN Question query
- * @returns {Object} Map of subcategory -> { medianAccuracy, medianElapsedTime, responseCount }
+ * @returns {Object} Map of subcategory -> { medianAccuracy, medianElapsedTime, medianPerformanceMetric, responseCount }
  */
 const computeSubcategoryBreakdown = (responses) => {
   const bySubcategory = {};
@@ -59,10 +67,11 @@ const computeSubcategoryBreakdown = (responses) => {
   const breakdown = {};
   for (const [sub, rows] of Object.entries(bySubcategory))
   {
-    const { medianAccuracy, medianElapsedTime } = computeAggregateStats(rows);
+    const { medianAccuracy, medianElapsedTime, medianPerformanceMetric } = computeAggregateStats(rows);
     breakdown[sub] = {
       medianAccuracy,
       medianElapsedTime,
+      medianPerformanceMetric,
       responseCount: rows.length,
     };
   }
@@ -82,7 +91,7 @@ const computeSubcategoryBreakdown = (responses) => {
  */
 const getAggregateStats = asyncHandler(async (req, res) => {
   const [responses] = await req.db.query(
-    `SELECT r.POINTS_EARNED, r.POINTS_POSSIBLE, r.ELAPSED_TIME, q.SUBCATEGORY
+    `SELECT r.POINTS_EARNED, r.POINTS_POSSIBLE, r.ELAPSED_TIME, q.SUBCATEGORY, q.TYPE
      FROM Response r
      JOIN User u     ON u.ID = r.USERID
      JOIN Question q ON q.ID = r.PROBLEM_ID
@@ -92,19 +101,21 @@ const getAggregateStats = asyncHandler(async (req, res) => {
   if (responses.length === 0)
   {
     return res.status(200).json({
-      medianAccuracy:       null,
-      medianElapsedTime:    null,
-      responseCount:        0,
-      subcategoryBreakdown: {},
+      medianAccuracy:           null,
+      medianElapsedTime:        null,
+      medianPerformanceMetric:  null,
+      responseCount:            0,
+      subcategoryBreakdown:     {},
     });
   }
 
-  const { medianAccuracy, medianElapsedTime } = computeAggregateStats(responses);
+  const { medianAccuracy, medianElapsedTime, medianPerformanceMetric } = computeAggregateStats(responses);
   const subcategoryBreakdown = computeSubcategoryBreakdown(responses);
 
   return res.status(200).json({
     medianAccuracy,
     medianElapsedTime,
+    medianPerformanceMetric,
     responseCount: responses.length,
     subcategoryBreakdown,
   });
@@ -141,9 +152,10 @@ const getAggregateStatsByQuestion = asyncHandler(async (req, res) => {
   }
 
   const [responses] = await req.db.query(
-    `SELECT r.POINTS_EARNED, r.POINTS_POSSIBLE, r.ELAPSED_TIME
+    `SELECT r.POINTS_EARNED, r.POINTS_POSSIBLE, r.ELAPSED_TIME, q.SUBCATEGORY, q.TYPE
      FROM Response r
      JOIN User u ON u.ID = r.USERID
+     JOIN Question q ON q.ID = r.PROBLEM_ID
      WHERE r.PROBLEM_ID = ? AND u.IS_SHARING_STATS = 1`,
     [questionId]
   );
@@ -152,18 +164,20 @@ const getAggregateStatsByQuestion = asyncHandler(async (req, res) => {
   {
     return res.status(200).json({
       questionId,
-      medianAccuracy:    null,
-      medianElapsedTime: null,
-      responseCount:     0,
+      medianAccuracy:           null,
+      medianElapsedTime:        null,
+      medianPerformanceMetric:  null,
+      responseCount:            0,
     });
   }
 
-  const { medianAccuracy, medianElapsedTime } = computeAggregateStats(responses);
+  const { medianAccuracy, medianElapsedTime, medianPerformanceMetric } = computeAggregateStats(responses);
 
   return res.status(200).json({
     questionId,
     medianAccuracy,
     medianElapsedTime,
+    medianPerformanceMetric,
     responseCount: responses.length,
   });
 });

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -633,7 +633,7 @@ paths:
       summary: Fetch aggregate stats across all opted-in users.
       operationId: getAggregateStats
       description: |
-        Returns median accuracy and median elapsed time across all responses from opted-in users.
+        Returns median accuracy, median elapsed time, and median performance metric (computed by AE) across all responses from opted-in users.
         - Also includes a per-subcategory breakdown of the same metrics.
         - Median is used rather than mean to reduce skew from outliers such as users who left their computer mid-question.
         - Returns nulls and an empty breakdown if no opted-in responses exist.
@@ -658,7 +658,7 @@ paths:
       summary: Fetch aggregate stats for a single question.
       operationId: getAggregateStatsByQuestion
       description: |
-        Returns median accuracy and median elapsed time for a single question, computed across all responses from opted-in users.
+        Returns median accuracy, median elapsed time, and median performance metric (computed by AE) for a single question, computed across all responses from opted-in users.
         - Returns nulls if no opted-in responses exist for the question.
       security:
         - BearerAuth: []
@@ -3123,6 +3123,11 @@ definitions:
         example: 60
         nullable: true
         description: Median elapsed time in seconds across opted-in responses with non-null times. Null if no data.
+      medianPerformanceMetric:
+        type: number
+        example: 0.6
+        nullable: true
+        description: Median "mastery" metric between 0 and 1 computed by the Analytics Engine (AE) across opted-in responses. Null if no data.
       responseCount:
         type: integer
         example: 120
@@ -3140,6 +3145,10 @@ definitions:
             medianElapsedTime:
               type: number
               example: 45
+              nullable: true
+            medianPerformanceMetric:
+              type: number
+              example: 0.55
               nullable: true
             responseCount:
               type: integer
@@ -3161,6 +3170,11 @@ definitions:
         example: 60
         nullable: true
         description: Median elapsed time in seconds across opted-in responses for this question. Null if no data.
+      medianPerformanceMetric:
+        type: number
+        example: 0.6
+        nullable: true
+        description: Median "mastery" metric between 0 and 1 computed by the Analytics Engine (AE) across opted-in responses. Null if no data.
       responseCount:
         type: integer
         example: 3

--- a/frontend/src/pages/ProfessorStatisticsPage.tsx
+++ b/frontend/src/pages/ProfessorStatisticsPage.tsx
@@ -27,34 +27,38 @@ interface TopicQuestionList
 
 
 interface StatData {
-    medianAccuracy?:        number;
-    medianElapsedTime?:     number;
-    responseCount:          number;
+    medianAccuracy?:          number;
+    medianElapsedTime?:       number;
+    medianPerformanceMetric?: number;
+    responseCount:            number;
 }
 
 interface SubcategoryBreakdown
 {
     [key: string]: {
-        medianAccuracy?:        number | null;
-        medianElapsedTime?:     number | null;
-        responseCount:          number;
+        medianAccuracy?:          number | null;
+        medianElapsedTime?:       number | null;
+        medianPerformanceMetric?: number | null;
+        responseCount:            number;
     }
 }
 
 interface AggregateStatsResponse
 {
-    medianAccuracy?:        number | null;
-    medianElapsedTime?:     number | null;
-    responseCount:          number;
-    subcategoryBreakdown:   SubcategoryBreakdown;
+    medianAccuracy?:          number | null;
+    medianElapsedTime?:       number | null;
+    medianPerformanceMetric?: number | null;
+    responseCount:            number;
+    subcategoryBreakdown:     SubcategoryBreakdown;
 }
 
 interface AggregateStatsByQuestionResponse
 {
-    questionID:             number;
-    medianAccuracy?:        number | null;
-    medianElapsedTime?:     number | null;
-    responseCount:          number;
+    questionID:               number;
+    medianAccuracy?:          number | null;
+    medianElapsedTime?:       number | null;
+    medianPerformanceMetric?: number | null;
+    responseCount:            number;
 }
 
 interface CheckQuestion
@@ -368,21 +372,23 @@ const ProfessorStatisticsPage: React.FC = () =>
         //console.log(aggregateStats)
         if (topicChoice.toLowerCase() === "All".toLowerCase()){
             const topicData: StatData = {
-                medianAccuracy:     aggregateStats?.medianAccuracy == undefined ? 0 : aggregateStats?.medianAccuracy == null ? 0 : aggregateStats.medianAccuracy,
-                medianElapsedTime:  aggregateStats?.medianElapsedTime == undefined ? 0 : aggregateStats?.medianElapsedTime == null ? 0 : aggregateStats.medianElapsedTime,
-                responseCount:      aggregateStats?.responseCount == undefined ? 0 : aggregateStats?.responseCount == null ? 0 : aggregateStats.responseCount
+                medianAccuracy:           aggregateStats?.medianAccuracy == undefined ? 0 : aggregateStats?.medianAccuracy == null ? 0 : aggregateStats.medianAccuracy,
+                medianElapsedTime:        aggregateStats?.medianElapsedTime == undefined ? 0 : aggregateStats?.medianElapsedTime == null ? 0 : aggregateStats.medianElapsedTime,
+                medianPerformanceMetric:  aggregateStats?.medianPerformanceMetric ?? 0,
+                responseCount:            aggregateStats?.responseCount == undefined ? 0 : aggregateStats?.responseCount == null ? 0 : aggregateStats.responseCount
             };
             setTopicStats(topicData);
             
         }
         else {
-            setTopicStats({medianAccuracy: 0, medianElapsedTime: 0, responseCount: 0});
+            setTopicStats({medianAccuracy: 0, medianElapsedTime: 0, medianPerformanceMetric: 0, responseCount: 0});
             ALL_TOPICS.map((topic) => {
                 if(topic.toLowerCase() === topicChoice.toLowerCase() && aggregateStats?.subcategoryBreakdown[topicChoice] != undefined)
                 {
                     const topicData: StatData = {
                         medianAccuracy: aggregateStats?.subcategoryBreakdown[topicChoice]?.medianAccuracy == undefined ? 0 : aggregateStats?.subcategoryBreakdown[topicChoice]?.medianAccuracy == null ? 0 : aggregateStats?.subcategoryBreakdown[topicChoice].medianAccuracy,
                         medianElapsedTime: aggregateStats?.subcategoryBreakdown[topicChoice]?.medianElapsedTime == undefined ? 0 : aggregateStats?.subcategoryBreakdown[topicChoice]?.medianElapsedTime == null ? 0 : aggregateStats?.subcategoryBreakdown[topicChoice].medianElapsedTime,
+                        medianPerformanceMetric: aggregateStats?.subcategoryBreakdown[topicChoice]?.medianPerformanceMetric ?? 0,
                         responseCount: aggregateStats?.subcategoryBreakdown[topicChoice]?.responseCount == undefined ? 0 : aggregateStats?.subcategoryBreakdown[topicChoice]?.responseCount == null ? 0 : aggregateStats?.subcategoryBreakdown[topicChoice].responseCount,
                     };  
                     setTopicStats(topicData);
@@ -409,13 +415,14 @@ const ProfessorStatisticsPage: React.FC = () =>
 
     const updateQuestionStats = (questionsAggregateStats: AggregateStatsByQuestionResponse[]) => {
         if (questionsAggregateStats.length < 1){
-            setQuestionStats({ medianAccuracy: 0, medianElapsedTime: 0, responseCount: 0 });
+            setQuestionStats({ medianAccuracy: 0, medianElapsedTime: 0, medianPerformanceMetric: 0, responseCount: 0 });
             return;
         }
         
         const length = questionsAggregateStats.length;
         let totalMedianElapsedTime = 0;
         let totalMedianAccuracy = 0;
+        let totalMedianPerformanceMetric = 0;
         let totalQuestionsCompleted = 0;
 
         //console.log('question agg stats' ,questionsAggregateStats)
@@ -423,6 +430,7 @@ const ProfessorStatisticsPage: React.FC = () =>
         questionsAggregateStats.map((question) => {
             totalMedianAccuracy += question?.medianAccuracy == undefined || question?.medianAccuracy == null ? 0 : question?.medianAccuracy;
             totalMedianElapsedTime += question?.medianElapsedTime == undefined || question?.medianElapsedTime == null ? 0 : question?.medianElapsedTime;
+            totalMedianPerformanceMetric += question?.medianPerformanceMetric ?? 0;
             totalQuestionsCompleted += question?.responseCount == undefined || question?.responseCount == null ? 0 : question?.responseCount;
         })
 
@@ -431,17 +439,18 @@ const ProfessorStatisticsPage: React.FC = () =>
         setQuestionStats({
             medianAccuracy: Math.round(totalMedianAccuracy*100 / length),
             medianElapsedTime: Math.round(totalMedianElapsedTime / length),
+            medianPerformanceMetric: parseFloat((totalMedianPerformanceMetric / length).toFixed(4)),
             responseCount: totalQuestionsCompleted
         })
     }
 
     const getPercentageGraphs = () => {
-
+        const mastery = topicStats?.medianPerformanceMetric ?? 0;
         
             return (
                 <div className="flex items-end gap-2 h-30">
                     <div className="flex-1 min-w-0 flex flex-col items-center gap-1">
-                        <div className="w-1/4 h-14 flex items-end">
+                        <div className="w-1/2 h-14 flex items-end">
                             <div className={`w-full rounded-t text-white text-center text-sm
                                 ${topicStats?.medianAccuracy !== undefined ? (topicStats?.medianAccuracy > 0  ? "bg-blue-500" : "bg-gray-300") : "bg-gray-300"}`}
                                 style={{ height: `${Math.max(12, (topicStats?.medianAccuracy !== undefined && topicStats?.medianAccuracy > 0) ? topicStats?.medianAccuracy*100*1.5 : 0)}%`
@@ -449,8 +458,21 @@ const ProfessorStatisticsPage: React.FC = () =>
                                 title={`${topicChoice}: ${Math.round(((topicStats?.medianAccuracy !== undefined && topicStats?.medianAccuracy > 0) ? topicStats.medianAccuracy : 0)*100)}% accuracy`}
                             >{((topicStats?.medianAccuracy !== undefined && topicStats?.medianAccuracy > 0) ? Math.round(topicStats.medianAccuracy*100) + '%' : '')}</div>
                         </div>
-                        <span className="text-[10px] text-gray-500 leading-none">Median Performance</span>
+                        <span className="text-[10px] text-gray-500 leading-none">Median Accuracy</span>
                     </div> 
+                    <div className="flex-1 min-w-0 flex flex-col items-center gap-1">
+                        <div className="w-1/2 h-14 flex items-end">
+                            <div
+                                className={`w-full rounded-t text-white text-center text-sm
+                                    ${mastery > 0 ? "bg-blue-500" : "bg-gray-300"}`}
+                                style={{ height: `${Math.max(12, (topicStats?.medianPerformanceMetric ?? 0) * 100 * 1.5)}%` }}
+                                title={`${topicChoice}: ${Math.round((topicStats?.medianPerformanceMetric ?? 0) * 100)}% mastery`}
+                            >
+                                {mastery > 0 ? Math.round(mastery * 100) + '%' : ''}
+                            </div>
+                        </div>
+                        <span className="text-[10px] text-gray-500 leading-none">Median Mastery</span>
+                    </div>
                     {/*
                     <div className="flex-1 min-w-0 flex flex-col items-center gap-1">
                         <div className="w-1/2 h-14 flex items-end">
@@ -479,6 +501,14 @@ const ProfessorStatisticsPage: React.FC = () =>
                 <div className="rounded-lg bg-gray-50 p-3 border border-gray-200 min-w-[220px] flex-1">
                     <p className="text-xs text-gray-500">Questions Completed</p>
                     <p className="text-xl font-bold text-gray-900">{topicStats?.responseCount}</p>
+                </div>
+                <div className="rounded-lg bg-gray-50 p-3 border border-gray-200 min-w-[220px] flex-1">
+                    <p className="text-xs text-gray-500">Median Mastery</p>
+                    <p className="text-xl font-bold text-gray-900">
+                        {topicStats?.medianPerformanceMetric !== undefined
+                            ? Math.round(topicStats.medianPerformanceMetric * 100) + '%'
+                            : '—'}
+                    </p>
                 </div>
             </div>
         )
@@ -516,6 +546,16 @@ const ProfessorStatisticsPage: React.FC = () =>
                     <p className="text-xs text-gray-500">{moreThanOneChecked ? 'Average Median Performance' : 'Median Perfomance'}</p>
                     <p className="text-xl font-bold text-gray-900">{questionStats?.medianAccuracy == undefined ? 0 : questionStats?.medianAccuracy}%</p>
                 </div>
+                <div className="rounded-lg bg-gray-50 p-3 border border-gray-200 min-w-[220px] flex-1">
+                    <p className="text-xs text-gray-500">
+                        {moreThanOneChecked ? 'Average Median Mastery' : 'Median Mastery'}
+                    </p>
+                    <p className="text-xl font-bold text-gray-900">
+                        {questionStats?.medianPerformanceMetric !== undefined
+                            ? Math.round((questionStats.medianPerformanceMetric) * 100) + '%'
+                            : '—'}
+                    </p>
+                </div>
             </div>
         ) : (
             <div className="mt-3 flex text-center justify-center py-10">
@@ -525,7 +565,7 @@ const ProfessorStatisticsPage: React.FC = () =>
     }
 
     const isSelected = (id: number) => {
-        console.log(checkQuestions.filter((question) => {return question.questionID === id}))
+        //console.log(checkQuestions.filter((question) => {return question.questionID === id}))
         return checkQuestions.filter((question) => {return question.questionID === id && question.isChecked}).length < 1 
             ?  false
             :  true;

--- a/frontend/src/pages/ProfessorStatisticsPage.tsx
+++ b/frontend/src/pages/ProfessorStatisticsPage.tsx
@@ -1,4 +1,21 @@
-// For Professors to view the statistics on questions
+////////////////////////////////////////////////////////////////
+//
+//  Project:       KnightWise
+//  Year:          2026
+//  Author(s):     KnightWise Team
+//  File:          ProfessorStatisticsPage.tsx
+//  Description:   For Professors to view the statistics on 
+//                 questions.
+//
+//  Dependencies:  react
+//                 api instance
+//                 Layout component
+//                 topicLabels
+//                 models
+//                 storeCosmetics
+//                 userCustomizationStore
+//
+////////////////////////////////////////////////////////////////
 
 import React, { useCallback, useEffect, useState, useMemo, useRef } from "react";
 import api from "../api";


### PR DESCRIPTION
This PR addresses [SCRUM-234: Add Performance Metric to Professor Aggregate Statistics](https://knightwise.atlassian.net/browse/SCRUM-234)
- As requested from our discussions before the Instructor Demo, the "mastery" metric calculated by the Analytics Engine (AE) is now visible on the Professor Statistics page for both all topics and single questions.

# Backend Support
- Modified endpoints:
  - **GET** `/api/stats/aggregate` now returns the AE "mastery" metric for all questions and by topic in the breakdown.
  - **GET** `/api/stats/aggregate/:id` now returns AE "mastery" metric for a single question.
- All updates are reflected in `swagger.yaml`.

# Frontend Support
- `ProfessorStatisticsPage.tsx`
  - Added minimal changes to support the AE metric:
    - Updated interface models to include the AE metric.
    - Added the AE to `resolveTopicData()`, `updateQuestionStats()`, the Percentage Graphs, and the Statistics Grids.
      - Renamed the "Median Performance" bar to "Median Accuracy" to better represent what it is and to not get it confused with the new "Median Mastery" bar.
      - I actually changed the width of the Percentage Graph bars from 1/4 to 1/2 to make it look better with the additional mastery bar (otherwise the two bars looked very far apart). Perhaps when we add the third bar for elapsed time we'll need to tweak this again.
    - Commented out an existing `console.log()`.

# Tests & Use Cases

- Below: All new and current tests pass.
<img width="816" height="338" alt="image" src="https://github.com/user-attachments/assets/b8f6712d-df99-45e6-8a5f-3f2d82df287d" />

- Below: New API response bodies for all-aggregate and single-question-aggregate statistics now show the median AE "mastery" metric, labeled "medianPerformanceMetric".
<img width="1764" height="973" alt="image" src="https://github.com/user-attachments/assets/3e3a77c5-85ad-4ec1-8fed-e702b8ad6bc8" />
<img width="1759" height="415" alt="image" src="https://github.com/user-attachments/assets/1cbf375a-709c-464f-bb98-a3b597539519" />

- Below: Median mastery visible in the Percentage Graph and Statistics Grid for all topics and a single question.
<img width="1918" height="953" alt="image" src="https://github.com/user-attachments/assets/efb4fda3-1a2b-48f2-8192-ab75bc695b8d" />

- Below: Median mastery visible for a specific topic (Arrays) in the topic breakdown.
<img width="1916" height="937" alt="image" src="https://github.com/user-attachments/assets/5d74cbdb-6913-4bd4-8492-a580874b1757" />

- Below: Average median mastery visible when selecting multiple individual questions, similar to the other stats.
<img width="1908" height="936" alt="image" src="https://github.com/user-attachments/assets/d436d40b-c3d7-4cd4-9c60-a1a4d1f11e88" />
