### PR TITLE
SCRUM-227: Record User Response Elapsed Time

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -262,6 +262,13 @@ const Dashboard: React.FC = () => {
     )
     : 0;
 
+  const weeklyAvgTime = useMemo(() => {
+    // We don't want to consider all the legacy untimed responses
+    const timedResponses = weeklyEntries.filter(e => toFiniteNumber(e.elapsedTime) > 0);
+    if (timedResponses.length === 0) return 0; // Let's not divide by 0
+    return Math.round(timedResponses.reduce((sum, e) => sum + toFiniteNumber(e.elapsedTime), 0) / timedResponses.length);
+  }, [weeklyEntries]);
+
   const weeklyActivity = useMemo(() => {
     const days: Array<{ key: string; label: string; attempts: number; correct: number }> = [];
 
@@ -438,7 +445,7 @@ const Dashboard: React.FC = () => {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
           <section className="rounded-xl border border-gray-200 bg-white p-5">
             <p className="text-xs uppercase tracking-wide text-gray-500 font-semibold">Weekly Performance</p>
-            <div className="mt-3 grid grid-cols-3 gap-3">
+            <div className="mt-3 grid grid-cols-4 gap-3">
               <div className="rounded-lg bg-gray-50 p-3 border border-gray-200">
                 <p className="text-xs text-gray-500">Attempts</p>
                 <p className="text-xl font-bold text-gray-900">{weeklyEntries.length}</p>
@@ -450,6 +457,12 @@ const Dashboard: React.FC = () => {
               <div className="rounded-lg bg-gray-50 p-3 border border-gray-200">
                 <p className="text-xs text-gray-500">Avg Score</p>
                 <p className="text-xl font-bold text-gray-900">{weeklyAverageScore}%</p>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-3 border border-gray-200">
+                <p className="text-xs text-gray-500">Avg Time</p>
+                <p className="text-xl font-bold text-gray-900">
+                  {weeklyAvgTime > 0 ? `${weeklyAvgTime}s` : "—"}
+                </p>
               </div>
             </div>
             <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-3">

--- a/frontend/src/components/StatsViewer.tsx
+++ b/frontend/src/components/StatsViewer.tsx
@@ -484,7 +484,7 @@ const StatsViewer: React.FC = () => {
               </div>
               <div className="rounded-lg bg-gray-50 p-3 border border-gray-200">
                   <p className="text-xs text-gray-500 mb-2">Average Time Per Problem</p>
-                  <p className="text-2xl font-bold text-gray-800 ">{statViewerData.AvgElapsedTime}</p>
+                  <p className="text-2xl font-bold text-gray-800 ">{statViewerData.AvgElapsedTime > 0 ? `${Math.round(statViewerData.AvgElapsedTime)}s` : "—"}</p>
               </div>
 
           </div>

--- a/frontend/src/pages/MockTestPage.tsx
+++ b/frontend/src/pages/MockTestPage.tsx
@@ -19,7 +19,7 @@
 //
 ////////////////////////////////////////////////////////////////
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState, useRef } from "react";
 import Layout from "../components/Layout";
 import MockTestInfo from "../components/MockTestInfo";
 import MockTestResult from "../components/MockTestResult";
@@ -177,6 +177,7 @@ const MockTestPage: React.FC = () => {
   const [passedTests, setPassedTests] = useState<number | null>(null);
   const [totalTests, setTotalTests] = useState<number | null>(null);
   const [progSubmitsRemaining, setProgSubmitsRemaining] = useState<number | null>(null);
+  const startTimeRef = useRef<number>(Date.now()); // Ref so we don't need to re-render on change
   const programmingLanguageIds: Record<string, number> = {
     C: 50,
     "C++": 54,
@@ -222,6 +223,8 @@ const MockTestPage: React.FC = () => {
   const questionType = current?.QUESTION_TYPE || 'multiple_choice';
 
   useEffect(() => {
+    // On question change, start the timer
+    startTimeRef.current = Date.now(); 
     if (questionType === "ranked_choice" && current?.options) {
       setSelectedOrder(current.options);
     } else if (questionType === "drag_and_drop") {
@@ -395,6 +398,7 @@ const MockTestPage: React.FC = () => {
       resetInteractionState();
       setTimeRemainingSeconds(clampTimeLimit(timeLimitMinutes) * 60);
       setCompletionReason("completed");
+      startTimeRef.current = Date.now(); // Reset timer on test start
       setStep("test");
     } catch (error) {
       console.error("Failed to prepare custom mock test", error);
@@ -422,6 +426,9 @@ const MockTestPage: React.FC = () => {
     // Disable submit button (prevents spam)
     setIsSubmitting(true);
 
+    // Stop timer (compute elapsed time in seconds)
+    const elapsedTime = Math.round((Date.now() - startTimeRef.current) / 1000);
+
     if (questionType === "programming") {
       const languageId = programmingLanguageIds[programmingLanguage];
       const token = localStorage.getItem("token");
@@ -444,6 +451,7 @@ const MockTestPage: React.FC = () => {
             code: programmingAnswer,
             languageId,
             isTestRun: false,
+            elapsedTime,
           },
           token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
         );
@@ -532,6 +540,7 @@ const MockTestPage: React.FC = () => {
           userAnswer,
           category: current.CATEGORY,
           topic: current.SUBCATEGORY,
+          elapsedTime,
         },
         submitConfig
       );

--- a/frontend/src/pages/ProfessorStatisticsPage.tsx
+++ b/frontend/src/pages/ProfessorStatisticsPage.tsx
@@ -560,7 +560,7 @@ const ProfessorStatisticsPage: React.FC = () =>
                     <p className="text-xl font-bold text-gray-900">{questionStats?.responseCount}</p>
                 </div>
                 <div className="rounded-lg bg-gray-50 p-3 border border-gray-200 min-w-[220px] flex-1">
-                    <p className="text-xs text-gray-500">{moreThanOneChecked ? 'Average Median Performance' : 'Median Perfomance'}</p>
+                    <p className="text-xs text-gray-500">{moreThanOneChecked ? 'Average Median Accuracy' : 'Median Accuracy'}</p>
                     <p className="text-xl font-bold text-gray-900">{questionStats?.medianAccuracy == undefined ? 0 : questionStats?.medianAccuracy}%</p>
                 </div>
                 <div className="rounded-lg bg-gray-50 p-3 border border-gray-200 min-w-[220px] flex-1">

--- a/frontend/src/pages/TopicTestPage.tsx
+++ b/frontend/src/pages/TopicTestPage.tsx
@@ -21,7 +21,7 @@
 ////////////////////////////////////////////////////////////////
 
 // this page shows questions related to the chosen topic
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import Layout from "../components/Layout";
 import MultipleChoice from "../components/MultipleChoice";
@@ -58,6 +58,7 @@ const TopicTestPage: React.FC = () => {
   const [passedTests, setPassedTests] = useState<number | null>(null);
   const [totalTests, setTotalTests] = useState<number | null>(null);
   const [progSubmitsRemaining, setProgSubmitsRemaining] = useState<number | null>(null);
+  const startTimeRef = useRef<number>(Date.now()); // Ref so we don't need to re-render on change
   const navigate = useNavigate();
   const programmingLanguageIds: Record<string, number> = {
     C: 50,
@@ -302,6 +303,9 @@ const TopicTestPage: React.FC = () => {
     if (!current || !hasAnswer || isSubmitting) return;
     setIsSubmitting(true);
 
+    // Stop timer (compute elapsed time in seconds)
+    const elapsedTime = Math.round((Date.now() - startTimeRef.current) / 1000);
+
     if (questionType === "programming") {
       setPointsEarned(null);
       setPointsPossible(null);
@@ -325,6 +329,7 @@ const TopicTestPage: React.FC = () => {
             code: programmingAnswer,
             languageId,
             isTestRun: false,
+            elapsedTime,
           },
           token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
         );
@@ -433,6 +438,7 @@ const TopicTestPage: React.FC = () => {
         userAnswer,
         category: String(current.CATEGORY || ""),
         topic: String(current.SUBCATEGORY || ""),
+        elapsedTime,
       };
 
       // Ensure payload can be JSON serialized
@@ -588,6 +594,8 @@ const TopicTestPage: React.FC = () => {
   })() : null;
 
   useEffect(() => {
+    // On question change, start the timer
+    startTimeRef.current = Date.now();
     if (questionType === "ranked_choice" && current?.options) {
       setSelectedOrder(current.options);
     } else if (questionType === "drag_and_drop") {


### PR DESCRIPTION
This PR addresses [SCRUM-227: Time elapsed on questions](https://knightwise.atlassian.net/browse/SCRUM-227).

This PR adds the frontend support necessary to record the elapsed time of a user response and send it to the backend for the User Progress Page, User Dashboard, Professor Statistics Page.

Feel free to `git checkout` this branch if you want to play around with the new elapsed time functionality. If you do I would recommend **not** using any demo account (**timetest**, **newerdan**) so that if you create data that looks weird it doesn't mess up our pretty demo values. 
Another benefit of using a separate account is that you can opt in and opt out and see how it affects aggregate statistics.

# Frontend Changes
`TopicTestPage.tsx`: 
- Implemented a behind-the-scenes timer that records the time elapsed (in seconds) between when a question is displayed to the user and when they submit the question. 
- This elapsed time is sent to the `/submit` endpoint (or `/submitCode` in the case of a programming question).

`MockTestPage.tsx`:
- Same thing as the Topic Test Page. Only meaningful difference is that in addition to resetting the timer when a new question is served, the timer also resets when a new test starts.

`Dashboard.tsx`:
- Added a fourth "Avg Time" card to the Weekly Performance section.

`StatsViewer.tsx`:
- Slightly changed how average elapsed time was displayed, now shows seconds suffix and checks for valid data.

`ProfessorStatisticsPage.tsx`:
- Removed one more instance of accuracy being called "performance" instead of "accuracy" for clarity.

Changes were tested locally.

# Use Case
- Below: Now when a user submits a question, it sends their elapsed time. 4 seconds in this case.
<img width="1919" height="946" alt="image" src="https://github.com/user-attachments/assets/b9e21bf1-e975-4231-805a-67391a6f3970" />

- Below: It also sends time for code submissions. This is important because it's a different endpoint.
<img width="1919" height="923" alt="image" src="https://github.com/user-attachments/assets/33a3854d-e498-40c4-8300-3ab21153085c" />

- Below: Now endpoints that previously showed null elapsed time actually show meaningful values.
- `/history`:
<img width="1919" height="947" alt="image" src="https://github.com/user-attachments/assets/28f8c8fe-ae25-4dde-b5f4-40e062aebf89" />
- `/stats/aggregate`:
<img width="1919" height="923" alt="image" src="https://github.com/user-attachments/assets/e4898064-907b-41a0-b145-8acd3ba8adfc" />
- `/stats/aggregate/:id`:
<img width="1919" height="935" alt="image" src="https://github.com/user-attachments/assets/81c4e3b5-2850-44c9-a3e6-7d141d47f15c" />

- Below: Average time can now be seen in the Weekly Performance section on the Dashboard.
<img width="1919" height="941" alt="image" src="https://github.com/user-attachments/assets/dcda3635-85a0-4a98-97c2-2f8aeb71a6d6" />

- Below: Average Time Per Problem actually has meaningful data now on User Progress Page.
- It's very cool to see the little dynamic message respond to the elapsed time now.
- As much as I'd have liked to put a bar in the graph for elapsed time, realistically it wouldn't have made sense. Average time doesn't really make sense as a percentage or bar with a "height" since we don't have any reference value to compare it to.
<img width="1918" height="949" alt="image" src="https://github.com/user-attachments/assets/b3915826-2fd7-41d6-8dd9-b40d8bbd0e0c" />

- Below: Selecting a specific topic shows the Average Time Per Problem for that specific topic.
<img width="1919" height="938" alt="image" src="https://github.com/user-attachments/assets/3724dbe3-255a-486c-a136-b43d7187eb41" />
- Yes KnightWise, I was rushing. Was it the 0% accuracy that gave it away?
<img width="1917" height="946" alt="image" src="https://github.com/user-attachments/assets/4e34b914-f826-4dd5-86e8-f8753b9bd722" />

- Below: Professor Statistics Page now shows meaningful elapsed time values.
- Again, didn't include a bar for elapsed time for reasons explained above.
- Note I changed one of the labels to "Median Accuracy" in commit [aca647c](https://github.com/KnightWiseUCF/knightwise/pull/52/commits/aca647cc2ac4cf997300189fbf48f8ddc0901d3e).
<img width="1919" height="941" alt="image" src="https://github.com/user-attachments/assets/cc8a16e4-c3de-490c-833d-c39c3ef9e79b" />

- Below: Works for viewing individual topic stats and Average Median Elapsed Time for individual questions.
<img width="1919" height="948" alt="image" src="https://github.com/user-attachments/assets/071c0634-d422-4706-b0b6-de4fdcca66ea" />
